### PR TITLE
fix(ci): recreate prerelease tag before publishing prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,4 +1,4 @@
-name: Prerelease
+name: Nightly
 
 on:
   push:
@@ -9,12 +9,12 @@ permissions:
   contents: write
 
 concurrency:
-  group: prerelease-main
+  group: nightly-main
   cancel-in-progress: true
 
 jobs:
   linux-prerelease:
-    name: Build and update Linux prerelease
+    name: Build and update Linux nightly
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -43,13 +43,13 @@ jobs:
           NIX_CONFIG: experimental-features = nix-command flakes
         run: nix run .#prerelease-bundle --print-build-logs
 
-      - name: Move prerelease tag to current commit
+      - name: Move nightly tag to current commit
         uses: actions/github-script@v7
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const ref = "tags/prerelease";
+            const ref = "tags/nightly";
 
             try {
               await github.rest.git.getRef({
@@ -78,12 +78,12 @@ jobs:
               });
             }
 
-      - name: Publish prerelease
+      - name: Publish nightly
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: prerelease
+          tag_name: nightly
           target_commitish: ${{ github.sha }}
-          name: prerelease
+          name: nightly
           prerelease: true
           make_latest: false
           overwrite_files: true

--- a/CI.md
+++ b/CI.md
@@ -52,11 +52,11 @@ Runs on `ubuntu-latest` only.
   - Configures and builds with CMake + Ninja (`-Werror` enabled)
   - Runs `clang-format --dry-run --Werror` against tracked C/C++ sources
 
-## 3) `Prerelease` workflow
+## 3) `Nightly` workflow
 
 File: `.github/workflows/prerelease.yml`
 
-Runs on pushes to the `main` branch and updates the fixed `prerelease` release
+Runs on pushes to the `main` branch and updates the fixed `nightly` release
 with a fresh Linux-only prebuilt compiler bundle.
 
 - Installs Nix (`cachix/install-nix-action`)
@@ -64,12 +64,12 @@ with a fresh Linux-only prebuilt compiler bundle.
   - `nix run .#lint --print-build-logs`
   - `nix run .#tests --print-build-logs`
 - Builds a release bundle with `nix run .#prerelease-bundle`
-- Ensures the `prerelease` tag exists at the current `main` commit
+- Ensures the `nightly` tag exists at the current `main` commit
   - Creates the tag when it has been deleted
   - Force-moves the tag on later pushes
 - Publishes `dist/cicest-x86_64-linux.tar.gz` with
   `softprops/action-gh-release`
-- Replaces the existing archive asset in that prerelease when a newer `main`
+- Replaces the existing archive asset in that nightly release when a newer `main`
   push arrives
 
 The tarball contains only the installed compiler toolchain needed to compile
@@ -89,8 +89,8 @@ The validation workflows trigger on:
 - Pushes to `main` or `master`
 - All pull requests
 
-The prerelease workflow triggers on pushes to `main` and updates the fixed
-`prerelease` tag/release.
+The nightly workflow triggers on pushes to `main` and updates the fixed
+`nightly` tag/release.
 
 ## Local Reproduction
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced prerelease tag handling to ensure consistent creation and proper commit identification in the release process.

* **Documentation**
  * Updated prerelease workflow documentation to clarify tag creation and management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->