### PR TITLE
feat: implement and test ct-required type parameter handling

### DIFF
--- a/compiler/cstc_ast/include/cstc_ast/ast.hpp
+++ b/compiler/cstc_ast/include/cstc_ast/ast.hpp
@@ -57,10 +57,10 @@ struct TypeRef {
     TypeRefPtr pointee;
     /// True when this type is prefixed with the `runtime` qualifier.
     bool is_runtime = false;
-    /// True when this annotation requires compile-time availability (`!runtime`/`const`).
-    bool requires_ct = false;
     /// Explicit generic arguments when `kind == TypeKind::Named`.
     std::vector<TypeRef> generic_args;
+    /// True when this annotation requires compile-time availability (`!runtime`/`const`).
+    bool requires_ct = false;
 };
 
 /// Generic parameter declared on an item.

--- a/compiler/cstc_ast/include/cstc_ast/ast.hpp
+++ b/compiler/cstc_ast/include/cstc_ast/ast.hpp
@@ -57,6 +57,8 @@ struct TypeRef {
     TypeRefPtr pointee;
     /// True when this type is prefixed with the `runtime` qualifier.
     bool is_runtime = false;
+    /// True when this annotation requires compile-time availability (`!runtime`/`const`).
+    bool requires_ct = false;
     /// Explicit generic arguments when `kind == TypeKind::Named`.
     std::vector<TypeRef> generic_args;
 };

--- a/compiler/cstc_ast/include/cstc_ast/printer.hpp
+++ b/compiler/cstc_ast/include/cstc_ast/printer.hpp
@@ -123,6 +123,8 @@ inline void print_attributes(
         rendered += ">";
     }
 
+    if (type.requires_ct)
+        return "!runtime " + rendered;
     if (type.is_runtime)
         return "runtime " + rendered;
     return rendered;

--- a/compiler/cstc_parser/src/parser.cpp
+++ b/compiler/cstc_parser/src/parser.cpp
@@ -90,12 +90,23 @@ private:
 
     [[nodiscard]] bool check(TokenKind kind) const { return peek().kind == kind; }
 
+    [[nodiscard]] bool check_contextual_keyword(std::string_view keyword) const {
+        return check(TokenKind::Identifier) && token_text(peek()) == keyword;
+    }
+
     [[nodiscard]] bool check_attribute_start() const {
         return check(TokenKind::LBracket) && peek(1).kind == TokenKind::LBracket;
     }
 
     [[nodiscard]] bool match(TokenKind kind) {
         if (!check(kind))
+            return false;
+        static_cast<void>(advance());
+        return true;
+    }
+
+    [[nodiscard]] bool match_contextual_keyword(std::string_view keyword) {
+        if (!check_contextual_keyword(keyword))
             return false;
         static_cast<void>(advance());
         return true;
@@ -916,8 +927,28 @@ private:
             auto inner = parse_type();
             if (!inner.has_value())
                 return std::unexpected(inner.error());
+            if (inner->requires_ct) {
+                return std::unexpected(make_error_here(
+                    "conflicting `runtime` and `!runtime` type qualifiers"));
+            }
 
             inner->is_runtime = true;
+            return std::move(*inner);
+        }
+
+        if (match_contextual_keyword("const")) {
+            auto inner = parse_type();
+            if (!inner.has_value())
+                return std::unexpected(inner.error());
+            if (inner->is_runtime) {
+                return std::unexpected(make_error_here(
+                    "conflicting `const` and `runtime` type qualifiers"));
+            }
+            if (inner->requires_ct) {
+                return std::unexpected(make_error_here("duplicate `!runtime` type qualifier"));
+            }
+
+            inner->requires_ct = true;
             return std::move(*inner);
         }
 
@@ -967,7 +998,22 @@ private:
                 .pointee = nullptr,
                 .generic_args = {},
             };
-        if (match(TokenKind::Bang))
+        if (match(TokenKind::Bang)) {
+            if (match(TokenKind::KwRuntime)) {
+                auto inner = parse_type();
+                if (!inner.has_value())
+                    return std::unexpected(inner.error());
+                if (inner->is_runtime) {
+                    return std::unexpected(make_error_here(
+                        "conflicting `!runtime` and `runtime` type qualifiers"));
+                }
+                if (inner->requires_ct) {
+                    return std::unexpected(make_error_here("duplicate `!runtime` type qualifier"));
+                }
+
+                inner->requires_ct = true;
+                return std::move(*inner);
+            }
             return ast::TypeRef{
                 .kind = ast::TypeKind::Never,
                 .symbol = previous().symbol,
@@ -975,6 +1021,7 @@ private:
                 .pointee = nullptr,
                 .generic_args = {},
             };
+        }
 
         auto identifier = consume_identifier("expected type name");
         if (!identifier.has_value())

--- a/compiler/cstc_parser/src/parser.cpp
+++ b/compiler/cstc_parser/src/parser.cpp
@@ -370,7 +370,7 @@ private:
         std::vector<ast::TypeRef> args;
 
         while (true) {
-            auto arg = parse_type();
+            auto arg = parse_type(false);
             if (!arg.has_value())
                 return std::unexpected(arg.error());
             args.push_back(std::move(*arg));
@@ -919,12 +919,15 @@ private:
         };
     }
 
-    [[nodiscard]] std::expected<ast::TypeRef, ParseError> parse_type() {
+    [[nodiscard]] std::expected<ast::TypeRef, ParseError> parse_type() { return parse_type(true); }
+
+    [[nodiscard]] std::expected<ast::TypeRef, ParseError>
+        parse_type(const bool allow_ct_requirement) {
         if (match(TokenKind::KwRuntime)) {
             if (check(TokenKind::KwRuntime)) {
                 return std::unexpected(make_error_here("duplicate `runtime` type qualifier"));
             }
-            auto inner = parse_type();
+            auto inner = parse_type(allow_ct_requirement);
             if (!inner.has_value())
                 return std::unexpected(inner.error());
             if (inner->requires_ct) {
@@ -937,7 +940,12 @@ private:
         }
 
         if (match_contextual_keyword("const")) {
-            auto inner = parse_type();
+            const Token qualifier = previous();
+            if (!allow_ct_requirement) {
+                return std::unexpected(
+                    make_error_token(qualifier, "nested `const` type qualifier is not supported"));
+            }
+            auto inner = parse_type(allow_ct_requirement);
             if (!inner.has_value())
                 return std::unexpected(inner.error());
             if (inner->is_runtime) {
@@ -953,7 +961,7 @@ private:
         }
 
         if (match(TokenKind::Amp)) {
-            auto inner = parse_type();
+            auto inner = parse_type(false);
             if (!inner.has_value())
                 return std::unexpected(inner.error());
 
@@ -999,8 +1007,13 @@ private:
                 .generic_args = {},
             };
         if (match(TokenKind::Bang)) {
+            const Token bang = previous();
             if (match(TokenKind::KwRuntime)) {
-                auto inner = parse_type();
+                if (!allow_ct_requirement) {
+                    return std::unexpected(make_error_token(
+                        bang, "nested `!runtime` type qualifier is not supported"));
+                }
+                auto inner = parse_type(allow_ct_requirement);
                 if (!inner.has_value())
                     return std::unexpected(inner.error());
                 if (inner->is_runtime) {

--- a/compiler/cstc_parser/src/parser.cpp
+++ b/compiler/cstc_parser/src/parser.cpp
@@ -928,8 +928,8 @@ private:
             if (!inner.has_value())
                 return std::unexpected(inner.error());
             if (inner->requires_ct) {
-                return std::unexpected(make_error_here(
-                    "conflicting `runtime` and `!runtime` type qualifiers"));
+                return std::unexpected(
+                    make_error_here("conflicting `runtime` and `!runtime` type qualifiers"));
             }
 
             inner->is_runtime = true;
@@ -941,8 +941,8 @@ private:
             if (!inner.has_value())
                 return std::unexpected(inner.error());
             if (inner->is_runtime) {
-                return std::unexpected(make_error_here(
-                    "conflicting `const` and `runtime` type qualifiers"));
+                return std::unexpected(
+                    make_error_here("conflicting `const` and `runtime` type qualifiers"));
             }
             if (inner->requires_ct) {
                 return std::unexpected(make_error_here("duplicate `!runtime` type qualifier"));
@@ -1004,8 +1004,8 @@ private:
                 if (!inner.has_value())
                     return std::unexpected(inner.error());
                 if (inner->is_runtime) {
-                    return std::unexpected(make_error_here(
-                        "conflicting `!runtime` and `runtime` type qualifiers"));
+                    return std::unexpected(
+                        make_error_here("conflicting `!runtime` and `runtime` type qualifiers"));
                 }
                 if (inner->requires_ct) {
                     return std::unexpected(make_error_here("duplicate `!runtime` type qualifier"));

--- a/compiler/cstc_parser/tests/parser_decls.cpp
+++ b/compiler/cstc_parser/tests/parser_decls.cpp
@@ -266,6 +266,23 @@ void test_runtime_type_prefixes() {
     assert(fn.return_type->pointee->symbol.as_str() == "Handle");
 }
 
+void test_ct_required_type_prefixes() {
+    cstc::symbol::SymbolSession session;
+    const auto prog = must_parse(
+        "fn reserve(count: !runtime num, cap: const num) -> !runtime num { count + cap }");
+    const auto& fn = std::get<cstc::ast::FnDecl>(prog.items[0]);
+    assert(fn.params.size() == 2);
+    assert(fn.params[0].type.kind == cstc::ast::TypeKind::Num);
+    assert(!fn.params[0].type.is_runtime);
+    assert(fn.params[0].type.requires_ct);
+    assert(fn.params[1].type.kind == cstc::ast::TypeKind::Num);
+    assert(!fn.params[1].type.is_runtime);
+    assert(fn.params[1].type.requires_ct);
+    assert(fn.return_type.has_value());
+    assert(fn.return_type->kind == cstc::ast::TypeKind::Num);
+    assert(fn.return_type->requires_ct);
+}
+
 void test_import_decl() {
     cstc::symbol::SymbolSession session;
     const auto prog = must_parse("import { Value, helper as alias } from \"path/to/foo.cst\";");
@@ -383,6 +400,16 @@ void test_let_with_type_annotation() {
     assert(let.type_annotation->kind == cstc::ast::TypeKind::Bool);
 }
 
+void test_let_ct_required_type_annotation() {
+    cstc::symbol::SymbolSession session;
+    const auto prog = must_parse("fn f() { let y: const num = 1; y }");
+    const auto& fn = std::get<cstc::ast::FnDecl>(prog.items[0]);
+    const auto& let = std::get<cstc::ast::LetStmt>(fn.body->statements[0]);
+    assert(let.type_annotation.has_value());
+    assert(let.type_annotation->kind == cstc::ast::TypeKind::Num);
+    assert(let.type_annotation->requires_ct);
+}
+
 void test_let_discard() {
     cstc::symbol::SymbolSession session;
     const auto prog = must_parse("fn f() { let _ = 0; }");
@@ -466,6 +493,7 @@ int main() {
     test_pub_runtime_fn();
     test_pub_extern_fn();
     test_runtime_type_prefixes();
+    test_ct_required_type_prefixes();
     test_import_decl();
     test_pub_import_decl();
     test_fn_never_return_type();
@@ -476,6 +504,7 @@ int main() {
     test_let_no_type_annotation();
     test_let_ref_type_annotation();
     test_let_with_type_annotation();
+    test_let_ct_required_type_annotation();
     test_let_discard();
     test_expr_stmt_semicolon();
     test_multiple_items();

--- a/compiler/cstc_parser/tests/parser_errors.cpp
+++ b/compiler/cstc_parser/tests/parser_errors.cpp
@@ -160,6 +160,21 @@ void test_error_duplicate_runtime_type_qualifier() {
         source.find("runtime runtime") + std::string_view{"runtime "}.size());
 }
 
+void test_error_nested_ct_required_ref_pointee() {
+    cstc::symbol::SymbolSession session;
+    expect_error("fn f(x: &!runtime num) { }", "nested `!runtime` type qualifier is not supported");
+}
+
+void test_error_nested_const_ref_pointee() {
+    cstc::symbol::SymbolSession session;
+    expect_error("fn f(x: &const num) { }", "nested `const` type qualifier is not supported");
+}
+
+void test_error_nested_ct_required_generic_argument() {
+    cstc::symbol::SymbolSession session;
+    expect_error("fn f(x: Box<const num>) { }", "nested `const` type qualifier is not supported");
+}
+
 void test_error_fn_missing_body() {
     cstc::symbol::SymbolSession session;
     expect_error("fn f()", "expected `{` to start block");
@@ -329,6 +344,9 @@ int main() {
     test_error_fn_missing_close_paren();
     test_error_fn_duplicate_param();
     test_error_duplicate_runtime_type_qualifier();
+    test_error_nested_ct_required_ref_pointee();
+    test_error_nested_const_ref_pointee();
+    test_error_nested_ct_required_generic_argument();
     test_error_fn_missing_body();
     test_error_duplicate_generic_parameter();
     test_error_missing_generic_parameter_name();

--- a/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
@@ -62,6 +62,12 @@ inline void indent(std::ostringstream& out, std::size_t level) {
     return "";
 }
 
+[[nodiscard]] inline std::string param_type_name(const TyParam& param) {
+    if (param.requires_ct())
+        return "!runtime " + param.ty.display();
+    return param.ty.display();
+}
+
 [[nodiscard]] inline std::string_view binary_name(cstc::ast::BinaryOp op) {
     switch (op) {
     case cstc::ast::BinaryOp::Add: return "+";
@@ -354,7 +360,8 @@ inline void print_ty_item(std::ostringstream& out, const TyItem& item, std::size
                 for (std::size_t i = 0; i < node.params.size(); ++i) {
                     if (i > 0)
                         out << ", ";
-                    out << node.params[i].name.as_str() << ": " << node.params[i].ty.display();
+                    out << node.params[i].name.as_str() << ": "
+                        << param_type_name(node.params[i]);
                 }
                 out << ") -> " << node.return_ty.display() << "\n";
                 cstc::ast::detail::print_where_clause(out, node.where_clause, level + 1);
@@ -366,7 +373,8 @@ inline void print_ty_item(std::ostringstream& out, const TyItem& item, std::size
                 for (std::size_t i = 0; i < node.params.size(); ++i) {
                     if (i > 0)
                         out << ", ";
-                    out << node.params[i].name.as_str() << ": " << node.params[i].ty.display();
+                    out << node.params[i].name.as_str() << ": "
+                        << param_type_name(node.params[i]);
                 }
                 out << ") -> " << node.return_ty.display() << "\n";
             } else if constexpr (std::is_same_v<T, TyExternStructDecl>) {

--- a/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
@@ -360,8 +360,7 @@ inline void print_ty_item(std::ostringstream& out, const TyItem& item, std::size
                 for (std::size_t i = 0; i < node.params.size(); ++i) {
                     if (i > 0)
                         out << ", ";
-                    out << node.params[i].name.as_str() << ": "
-                        << param_type_name(node.params[i]);
+                    out << node.params[i].name.as_str() << ": " << param_type_name(node.params[i]);
                 }
                 out << ") -> " << node.return_ty.display() << "\n";
                 cstc::ast::detail::print_where_clause(out, node.where_clause, level + 1);
@@ -373,8 +372,7 @@ inline void print_ty_item(std::ostringstream& out, const TyItem& item, std::size
                 for (std::size_t i = 0; i < node.params.size(); ++i) {
                     if (i > 0)
                         out << ", ";
-                    out << node.params[i].name.as_str() << ": "
-                        << param_type_name(node.params[i]);
+                    out << node.params[i].name.as_str() << ": " << param_type_name(node.params[i]);
                 }
                 out << ") -> " << node.return_ty.display() << "\n";
             } else if constexpr (std::is_same_v<T, TyExternStructDecl>) {

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -500,7 +500,9 @@ struct TyReturn {
 /// Every `TyExpr` carries:
 /// - `node`: the concrete expression variant,
 /// - `ty`:   the inferred or annotated type,
-/// - `span`: the source location.
+/// - `span`: the source location,
+/// - `ct_available`: whether the expression value is guaranteed available at
+///   compile time, independent of the static type shape.
 struct TyExpr {
     /// Variant payload for all typed expression forms.
     using Node = std::variant<
@@ -514,11 +516,14 @@ struct TyExpr {
     Ty ty;
     /// Source location for this expression.
     cstc::span::SourceSpan span;
+    /// True when this expression is guaranteed not to depend on runtime input.
+    bool ct_available = true;
 };
 
 /// Constructs a heap-allocated typed expression.
-[[nodiscard]] inline TyExprPtr make_ty_expr(cstc::span::SourceSpan span, TyExpr::Node node, Ty ty) {
-    return std::make_shared<TyExpr>(TyExpr{std::move(node), std::move(ty), span});
+[[nodiscard]] inline TyExprPtr
+    make_ty_expr(cstc::span::SourceSpan span, TyExpr::Node node, Ty ty, bool ct_available = true) {
+    return std::make_shared<TyExpr>(TyExpr{std::move(node), std::move(ty), span, ct_available});
 }
 
 // ─── Statements ──────────────────────────────────────────────────────────────
@@ -567,6 +572,8 @@ struct TyBlock {
     Ty ty;
     /// Source location for the full block.
     cstc::span::SourceSpan span;
+    /// True when the block's yielded value is guaranteed compile-time available.
+    bool ct_available = true;
 };
 
 /// Typed generic constraint attached to a generic declaration.

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -637,6 +637,14 @@ struct TyEnumDecl {
     std::vector<TyGenericConstraint> lowered_where_clause;
 };
 
+/// Availability requirement attached to a function parameter.
+enum class ParamRequirement {
+    /// Runtime-dependent arguments are accepted by the ordinary lifted-call rule.
+    RuntimeAllowed,
+    /// The call argument must be compile-time available.
+    CtRequired,
+};
+
 /// Typed function parameter declaration.
 struct TyParam {
     /// Parameter name.
@@ -645,6 +653,13 @@ struct TyParam {
     Ty ty;
     /// Source location for the parameter.
     cstc::span::SourceSpan span;
+    /// Availability requirement enforced at call sites.
+    ParamRequirement requirement = ParamRequirement::RuntimeAllowed;
+
+    /// Returns true when this parameter rejects runtime-dependent arguments.
+    [[nodiscard]] constexpr bool requires_ct() const {
+        return requirement == ParamRequirement::CtRequired;
+    }
 };
 
 /// Typed function item declaration.

--- a/compiler/cstc_tyir/include/cstc_tyir/type_compat.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/type_compat.hpp
@@ -16,6 +16,22 @@ namespace cstc::tyir {
     return lhs.same_shape_as(rhs);
 }
 
+/// Returns true when `ty` or any nested type argument/pointee carries the
+/// `runtime` qualifier.
+[[nodiscard]] inline bool type_has_runtime_dependency(const Ty& ty) {
+    if (ty.is_runtime)
+        return true;
+    if (ty.kind == TyKind::Ref)
+        return ty.pointee != nullptr && type_has_runtime_dependency(*ty.pointee);
+    if (ty.kind != TyKind::Named)
+        return false;
+    for (const Ty& arg : ty.generic_args) {
+        if (type_has_runtime_dependency(arg))
+            return true;
+    }
+    return false;
+}
+
 /// Returns true when `actual` may appear where `expected` is required.
 ///
 /// `Never` (bottom type) is compatible with any expected type. Outside of

--- a/compiler/cstc_tyir/tests/tyir_print.cpp
+++ b/compiler/cstc_tyir/tests/tyir_print.cpp
@@ -211,6 +211,28 @@ static void test_print_runtime_items() {
     assert(contains(out, "TyExternFnDecl \"lang\" poll(value: &runtime str) -> Unit"));
 }
 
+static void test_print_ct_required_parameter() {
+    TyFnDecl fn;
+    fn.name = Symbol::intern("reserve");
+    fn.params = {
+        TyParam{
+                Symbol::intern("count"),
+                ty::num(),
+                {},
+                ParamRequirement::CtRequired,
+                },
+    };
+    fn.return_ty = ty::num();
+    fn.body = std::make_shared<TyBlock>();
+    fn.body->ty = ty::num();
+
+    TyProgram prog;
+    prog.items.push_back(std::move(fn));
+
+    const std::string out = format_program(prog);
+    assert(contains(out, "TyFnDecl reserve(count: !runtime num) -> num"));
+}
+
 static void test_print_generic_fn_metadata() {
     TyFnDecl fn;
     fn.name = Symbol::intern("id");
@@ -723,6 +745,7 @@ int main() {
     test_print_lang_item_enum();
     test_print_enum_with_discriminant();
     test_print_runtime_items();
+    test_print_ct_required_parameter();
     test_print_generic_fn_metadata();
     test_print_call_and_struct_init_generic_args();
     test_print_deferred_generic_call();

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -22,6 +22,7 @@ namespace detail {
 using tyir::common_type;
 using tyir::compatible;
 using tyir::matches_type_shape;
+using tyir::type_has_runtime_dependency;
 
 // ─── Type environment ────────────────────────────────────────────────────────
 
@@ -330,20 +331,6 @@ using TypeSubstitution =
             erased.generic_args.push_back(erase_runtime_qualifiers(arg));
     }
     return erased;
-}
-
-[[nodiscard]] static bool type_has_runtime_dependency(const tyir::Ty& ty) {
-    if (ty.is_runtime)
-        return true;
-    if (ty.kind == tyir::TyKind::Ref)
-        return ty.pointee != nullptr && type_has_runtime_dependency(*ty.pointee);
-    if (ty.kind != tyir::TyKind::Named)
-        return false;
-    for (const tyir::Ty& arg : ty.generic_args) {
-        if (type_has_runtime_dependency(arg))
-            return true;
-    }
-    return false;
 }
 
 [[nodiscard]] static bool value_is_ct_available(const bool ct_available, const tyir::Ty& ty) {

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -355,7 +355,7 @@ using TypeSubstitution =
 }
 
 [[nodiscard]] static std::string ct_required_type_display(const tyir::Ty& ty) {
-    return "!runtime " + erase_runtime_qualifiers(ty).display();
+    return "const " + erase_runtime_qualifiers(ty).display();
 }
 
 [[nodiscard]] static bool call_argument_may_be_compatible_after_generic_substitution(

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -948,7 +948,7 @@ struct LowerCtx {
         return {};
     }
 
-    std::string param_name = "argument " + std::to_string(param_index + 1);
+    std::string param_name = std::to_string(param_index + 1);
     if (param_index < sig.param_names.size() && sig.param_names[param_index].is_valid())
         param_name = "`" + std::string(sig.param_names[param_index].as_str()) + "`";
 

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -27,6 +27,7 @@ using tyir::matches_type_shape;
 
 /// Signature stored for each top-level function.
 struct FnSignature {
+    std::vector<cstc::symbol::Symbol> param_names;
     std::vector<tyir::Ty> param_types;
     std::vector<tyir::ParamRequirement> param_requirements;
     tyir::Ty return_ty;
@@ -348,6 +349,10 @@ using TypeSubstitution =
 [[nodiscard]] static bool
     call_argument_compatible(const tyir::Ty& actual, const tyir::Ty& expected) {
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
+}
+
+[[nodiscard]] static std::string ct_required_type_display(const tyir::Ty& ty) {
+    return "!runtime " + erase_runtime_qualifiers(ty).display();
 }
 
 [[nodiscard]] static bool call_argument_may_be_compatible_after_generic_substitution(
@@ -924,6 +929,37 @@ struct LowerCtx {
     return std::unexpected(LowerError{span, std::move(msg), std::nullopt});
 }
 
+[[nodiscard]] static std::expected<void, LowerError> require_ct_call_argument(
+    const FnSignature& sig, std::size_t param_index, const tyir::TyExprPtr& arg,
+    const tyir::Ty& expected_ty, cstc::span::SourceSpan span) {
+    if (param_index >= sig.param_requirements.size()
+        || sig.param_requirements[param_index] != tyir::ParamRequirement::CtRequired
+        || !type_has_runtime_dependency(arg->ty)) {
+        return {};
+    }
+
+    std::string param_name = "argument " + std::to_string(param_index + 1);
+    if (param_index < sig.param_names.size() && sig.param_names[param_index].is_valid())
+        param_name = "`" + std::string(sig.param_names[param_index].as_str()) + "`";
+
+    return make_error(
+        span, "argument " + param_name + " must be compile-time available: expected '"
+                  + ct_required_type_display(expected_ty) + "', found '" + arg->ty.display()
+                  + "'");
+}
+
+[[nodiscard]] static std::expected<void, LowerError> require_ct_annotation_value(
+    bool requires_ct, const tyir::TyExprPtr& value, const tyir::Ty& expected_ty,
+    cstc::span::SourceSpan span, std::string_view context) {
+    if (!requires_ct || !type_has_runtime_dependency(value->ty))
+        return {};
+
+    return make_error(
+        span, std::string(context) + " must be compile-time available: expected '"
+                  + ct_required_type_display(expected_ty) + "', found '" + value->ty.display()
+                  + "'");
+}
+
 [[nodiscard]] static std::string
     display_symbol(cstc::symbol::Symbol display_name, cstc::symbol::Symbol fallback) {
     if (display_name.is_valid())
@@ -1358,6 +1394,7 @@ struct LoweredPlace {
         auto pt = lower_type(p.type, env, p.span, generic_param_set);
         if (!pt)
             return std::unexpected(std::move(pt.error()));
+        sig.param_names.push_back(p.name);
         sig.param_types.push_back(*pt);
         sig.param_requirements.push_back(
             p.type.requires_ct ? tyir::ParamRequirement::CtRequired
@@ -1831,6 +1868,10 @@ struct ParamReferenceVisitor {
                                                 + "', found '" + resolved_args[index]->ty.display()
                                                 + "'");
         }
+        auto ct_check = require_ct_call_argument(
+            sig, index, resolved_args[index], expected_param_ty, resolved_args[index]->span);
+        if (!ct_check)
+            return std::unexpected(std::move(ct_check.error()));
     }
 
     const tyir::Ty lifted_return_ty = lift_call_result_type(resolved_return_ty, resolved_args);
@@ -2129,10 +2170,22 @@ struct ParamReferenceVisitor {
                     init->expr = std::move(*resolved_init);
                     if (!compatible(init->expr->ty, *ann)
                         && !should_defer_generic_probe_failure(
-                            init->expr->ty, *ann, ctx, init->deferred_generic_probe_validation))
+                            init->expr->ty, *ann, ctx, init->deferred_generic_probe_validation)) {
+                        if (s.type_annotation->requires_ct
+                            && call_argument_compatible(init->expr->ty, *ann)) {
+                            auto ct_check = require_ct_annotation_value(
+                                true, init->expr, *ann, s.span, "let binding");
+                            if (!ct_check)
+                                return std::unexpected(std::move(ct_check.error()));
+                        }
                         return make_error(
                             s.span, "type mismatch in let binding: expected '" + ann->display()
                                         + "', found '" + init->expr->ty.display() + "'");
+                    }
+                    auto ct_check = require_ct_annotation_value(
+                        s.type_annotation->requires_ct, init->expr, *ann, s.span, "let binding");
+                    if (!ct_check)
+                        return std::unexpected(std::move(ct_check.error()));
                     binding_ty = *ann;
                 } else {
                     if (auto unresolved = find_unresolved_deferred_generic_call(
@@ -2980,12 +3033,17 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         lowered_args[i] = std::move(*resolved_arg);
                         if (!call_argument_compatible(lowered_args[i]->ty, expected_param_ty)
                             && !should_defer_generic_call_argument_failure(
-                                lowered_args[i]->ty, expected_param_ty, ctx))
+                                lowered_args[i]->ty, expected_param_ty, ctx)) {
                             return make_error(
                                 node.args[i]->span, "argument " + std::to_string(i + 1) + " of '"
                                                         + display_fn_name + "': expected '"
                                                         + expected_param_ty.display() + "', found '"
                                                         + lowered_args[i]->ty.display() + "'");
+                        }
+                        auto ct_check = require_ct_call_argument(
+                            sig, i, lowered_args[i], expected_param_ty, node.args[i]->span);
+                        if (!ct_check)
+                            return std::unexpected(std::move(ct_check.error()));
                     }
 
                     const tyir::Ty lifted_return_ty =
@@ -3228,11 +3286,28 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             if (!compatible(init_expr->expr->ty, *ann)
                                 && !should_defer_generic_probe_failure(
                                     init_expr->expr->ty, *ann, ctx)) {
+                                if (init_let->type_annotation->requires_ct
+                                    && call_argument_compatible(init_expr->expr->ty, *ann)) {
+                                    auto ct_check = require_ct_annotation_value(
+                                        true, init_expr->expr, *ann, init_let->span,
+                                        "for-init binding");
+                                    if (!ct_check) {
+                                        ctx.scope.pop();
+                                        return std::unexpected(std::move(ct_check.error()));
+                                    }
+                                }
                                 ctx.scope.pop();
                                 return make_error(
                                     init_let->span, "for-init type mismatch: expected '"
                                                         + ann->display() + "', found '"
                                                         + init_expr->expr->ty.display() + "'");
+                            }
+                            auto ct_check = require_ct_annotation_value(
+                                init_let->type_annotation->requires_ct, init_expr->expr, *ann,
+                                init_let->span, "for-init binding");
+                            if (!ct_check) {
+                                ctx.scope.pop();
+                                return std::unexpected(std::move(ct_check.error()));
                             }
                             init_ty = *ann;
                         } else {

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -346,6 +346,22 @@ using TypeSubstitution =
     return false;
 }
 
+[[nodiscard]] static bool value_is_ct_available(const bool ct_available, const tyir::Ty& ty) {
+    return ct_available && !type_has_runtime_dependency(ty);
+}
+
+[[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
+    return expr != nullptr && value_is_ct_available(expr->ct_available, expr->ty);
+}
+
+[[nodiscard]] static bool all_exprs_ct_available(const std::vector<tyir::TyExprPtr>& exprs) {
+    for (const tyir::TyExprPtr& expr : exprs) {
+        if (!expr_value_is_ct_available(expr))
+            return false;
+    }
+    return true;
+}
+
 [[nodiscard]] static bool
     call_argument_compatible(const tyir::Ty& actual, const tyir::Ty& expected) {
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
@@ -482,6 +498,7 @@ public:
         bool moved = false;
         std::size_t active_borrows = 0;
         std::optional<std::size_t> borrowed_local;
+        bool ct_available = true;
     };
 
     void push() { frames_.push_back(Frame{{}, locals_.size()}); }
@@ -501,7 +518,7 @@ public:
 
     [[nodiscard]] bool insert(
         cstc::symbol::Symbol name, tyir::Ty ty,
-        std::optional<std::size_t> borrowed_local = std::nullopt) {
+        std::optional<std::size_t> borrowed_local = std::nullopt, bool ct_available = true) {
         assert(!frames_.empty());
         if (frames_.back().bindings.contains(name))
             return false;
@@ -510,7 +527,8 @@ public:
             locals_.at(*borrowed_local).active_borrows += 1;
 
         const std::size_t index = locals_.size();
-        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local});
+        const bool stored_ct_available = value_is_ct_available(ct_available, ty);
+        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local, stored_ct_available});
         frames_.back().bindings.emplace(name, index);
         return true;
     }
@@ -541,6 +559,7 @@ public:
             locals_[i].moved = locals_[i].moved || other.locals_[i].moved;
             locals_[i].active_borrows =
                 std::max(locals_[i].active_borrows, other.locals_[i].active_borrows);
+            locals_[i].ct_available = locals_[i].ct_available && other.locals_[i].ct_available;
         }
     }
 
@@ -566,6 +585,8 @@ struct LoopCtx {
     /// yet; once a `break` is encountered the type is set (bare `break` → Unit,
     /// `break expr` → expr type).  Subsequent breaks must unify.
     std::optional<tyir::Ty> break_ty;
+    /// Compile-time availability of accumulated break values.
+    std::optional<bool> break_ct_available;
 };
 
 // ─── Lowering context ────────────────────────────────────────────────────────
@@ -593,7 +614,9 @@ struct LowerCtx {
     }
 
     /// Push a new loop context for the given loop kind.
-    void push_loop(LoopKind kind) { loop_stack.push_back(LoopCtx{kind, std::nullopt}); }
+    void push_loop(LoopKind kind) {
+        loop_stack.push_back(LoopCtx{kind, std::nullopt, std::nullopt});
+    }
 
     /// Pop the innermost loop context.
     void pop_loop() {
@@ -934,7 +957,7 @@ struct LowerCtx {
     const tyir::Ty& expected_ty, cstc::span::SourceSpan span) {
     if (param_index >= sig.param_requirements.size()
         || sig.param_requirements[param_index] != tyir::ParamRequirement::CtRequired
-        || !type_has_runtime_dependency(arg->ty)) {
+        || expr_value_is_ct_available(arg)) {
         return {};
     }
 
@@ -950,7 +973,7 @@ struct LowerCtx {
 [[nodiscard]] static std::expected<void, LowerError> require_ct_annotation_value(
     bool requires_ct, const tyir::TyExprPtr& value, const tyir::Ty& expected_ty,
     cstc::span::SourceSpan span, std::string_view context) {
-    if (!requires_ct || !type_has_runtime_dependency(value->ty))
+    if (!requires_ct || expr_value_is_ct_available(value))
         return {};
 
     return make_error(
@@ -1741,7 +1764,11 @@ struct ParamReferenceVisitor {
             (*block)->tail = std::move(*resolved_tail);
             (*block)->ty =
                 block_can_fallthrough(**block) ? (*(*block)->tail)->ty : tyir::ty::never();
+            (*block)->ct_available = value_is_ct_available(
+                block_can_fallthrough(**block) ? expr_value_is_ct_available(*(*block)->tail) : true,
+                (*block)->ty);
             expr->ty = (*block)->ty;
+            expr->ct_available = (*block)->ct_available;
         }
         return expr;
     }
@@ -1759,10 +1786,16 @@ struct ParamReferenceVisitor {
             runtime_block->body->ty = block_can_fallthrough(*runtime_block->body)
                                         ? (*runtime_block->body->tail)->ty
                                         : tyir::ty::never();
+            runtime_block->body->ct_available = value_is_ct_available(
+                block_can_fallthrough(*runtime_block->body)
+                    ? expr_value_is_ct_available(*runtime_block->body->tail)
+                    : true,
+                runtime_block->body->ty);
             expr->ty = runtime_block->body->ty;
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
+        expr->ct_available = false;
         return expr;
     }
 
@@ -1776,6 +1809,11 @@ struct ParamReferenceVisitor {
             if_expr->then_block->ty = block_can_fallthrough(*if_expr->then_block)
                                         ? (*if_expr->then_block->tail)->ty
                                         : tyir::ty::never();
+            if_expr->then_block->ct_available = value_is_ct_available(
+                block_can_fallthrough(*if_expr->then_block)
+                    ? expr_value_is_ct_available(*if_expr->then_block->tail)
+                    : true,
+                if_expr->then_block->ty);
         }
 
         if (if_expr->else_branch.has_value() && expr_can_fallthrough(*(*if_expr->else_branch))) {
@@ -1794,6 +1832,13 @@ struct ParamReferenceVisitor {
                 return std::unexpected(std::move(joined_ty.error()));
             expr->ty = *joined_ty;
         }
+        const bool else_ct_available = if_expr->else_branch.has_value()
+                                         ? expr_value_is_ct_available(*if_expr->else_branch)
+                                         : true;
+        expr->ct_available = value_is_ct_available(
+            expr_value_is_ct_available(if_expr->condition) && if_expr->then_block->ct_available
+                && else_ct_available,
+            expr->ty);
         return expr;
     }
 
@@ -1837,11 +1882,13 @@ struct ParamReferenceVisitor {
     const tyir::Ty resolved_return_ty = call_result_type(
         annotate_type_semantics(apply_substitution(sig.return_ty, substitution), ctx.env),
         deferred->args);
+    const bool deferred_call_ct_available =
+        value_is_ct_available(all_exprs_ct_available(deferred->args), resolved_return_ty);
     if (!fully_resolved) {
         return tyir::make_ty_expr(
             expr->span,
             tyir::TyDeferredGenericCall{deferred->fn_name, std::move(generic_args), deferred->args},
-            resolved_return_ty);
+            resolved_return_ty, deferred_call_ct_available);
     }
 
     std::vector<tyir::Ty> concrete_generic_args;
@@ -1874,11 +1921,13 @@ struct ParamReferenceVisitor {
     }
 
     const tyir::Ty lifted_return_ty = lift_call_result_type(resolved_return_ty, resolved_args);
+    const bool call_ct_available =
+        value_is_ct_available(all_exprs_ct_available(resolved_args), lifted_return_ty);
 
     return tyir::make_ty_expr(
         expr->span,
         tyir::TyCall{deferred->fn_name, std::move(concrete_generic_args), std::move(resolved_args)},
-        lifted_return_ty);
+        lifted_return_ty, call_ct_available);
 }
 
 [[nodiscard]] static std::expected<cstc::symbol::Symbol, LowerError>
@@ -1946,7 +1995,9 @@ struct ParamReferenceVisitor {
     if (!constraint_fn)
         return std::unexpected(std::move(constraint_fn.error()));
 
-    return tyir::make_ty_expr(expr->span, tyir::TyCall{*constraint_fn, {}, {expr}}, *constraint_ty);
+    return tyir::make_ty_expr(
+        expr->span, tyir::TyCall{*constraint_fn, {}, {expr}}, *constraint_ty,
+        expr_value_is_ct_available(expr));
 }
 
 [[nodiscard]] static std::expected<std::vector<tyir::TyGenericConstraint>, LowerError>
@@ -1981,7 +2032,7 @@ struct ParamReferenceVisitor {
         }
 
         for (const tyir::TyParam& param : *params) {
-            if (!ctx.scope.insert(param.name, param.ty)) {
+            if (!ctx.scope.insert(param.name, param.ty, std::nullopt, param.requires_ct())) {
                 ctx.scope.pop();
                 return make_error(
                     param.span, "duplicate parameter '" + std::string(param.name.as_str()) + "'");
@@ -2159,6 +2210,7 @@ struct ParamReferenceVisitor {
 
                 // Resolve binding type (explicit annotation or infer from init)
                 tyir::Ty binding_ty;
+                bool binding_ct_available = true;
                 if (s.type_annotation.has_value()) {
                     auto ann = lower_type(*s.type_annotation, ctx.env, s.span, ctx.generic_params);
                     if (!ann)
@@ -2186,6 +2238,7 @@ struct ParamReferenceVisitor {
                     if (!ct_check)
                         return std::unexpected(std::move(ct_check.error()));
                     binding_ty = *ann;
+                    binding_ct_available = expr_value_is_ct_available(init->expr);
                 } else {
                     if (auto unresolved = find_unresolved_deferred_generic_call(
                             init->expr, ctx.env, ctx.generic_params);
@@ -2195,6 +2248,7 @@ struct ParamReferenceVisitor {
                                         + std::string(unresolved->as_str()) + "'");
                     }
                     binding_ty = init->expr->ty;
+                    binding_ct_available = expr_value_is_ct_available(init->expr);
                 }
 
                 // Register binding in scope (unless discard pattern)
@@ -2211,7 +2265,7 @@ struct ParamReferenceVisitor {
                         "borrow instead");
                 }
                 if (!s.discard && s.name.is_valid()
-                    && !ctx.scope.insert(s.name, binding_ty, borrowed_local))
+                    && !ctx.scope.insert(s.name, binding_ty, borrowed_local, binding_ct_available))
                     return make_error(
                         s.span, "duplicate local binding '" + std::string(s.name.as_str()) + "'");
 
@@ -2356,9 +2410,12 @@ struct ParamReferenceVisitor {
         release_temp_borrows(ctx, tail->temp_borrows);
         result.tail = std::move(tail->expr);
         result.ty = reaches_tail ? (*result.tail)->ty : tyir::ty::never();
+        result.ct_available = reaches_tail ? expr_value_is_ct_available(*result.tail) : true;
     } else {
         result.ty = reaches_tail ? tyir::ty::unit() : tyir::ty::never();
+        result.ct_available = true;
     }
+    result.ct_available = value_is_ct_available(result.ct_available, result.ty);
 
     ctx.scope.pop();
     return result;
@@ -2391,6 +2448,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
             continue;
         if (!target[i].break_ty.has_value()) {
             target[i].break_ty = source[i].break_ty;
+            target[i].break_ct_available = source[i].break_ct_available;
             continue;
         }
 
@@ -2400,6 +2458,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
         if (!joined)
             return std::unexpected(std::move(joined.error()));
         target[i].break_ty = *joined;
+        if (source[i].break_ct_available.has_value()) {
+            target[i].break_ct_available =
+                target[i].break_ct_available.value_or(true) && *source[i].break_ct_available;
+        }
     }
     return {};
 }
@@ -2432,8 +2494,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 return LoweredPlace{
                     tyir::make_ty_expr(
-                        expr->span, tyir::LocalRef{node.head, tyir::ValueUseKind::Borrow},
-                        local.ty),
+                        expr->span, tyir::LocalRef{node.head, tyir::ValueUseKind::Borrow}, local.ty,
+                        local.ct_available),
                     local_index,
                 };
             } else if constexpr (std::is_same_v<N, ast::FieldAccessExpr>) {
@@ -2465,13 +2527,14 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 tyir::Ty lowered_field_ty =
                     propagate_runtime_tag(*field_ty, base->expr->ty.is_runtime);
+                const bool field_ct_available = expr_value_is_ct_available(base->expr);
 
                 return LoweredPlace{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{
                             std::move(base->expr), node.field, tyir::ValueUseKind::Borrow},
-                        lowered_field_ty),
+                        lowered_field_ty, field_ct_available),
                     base->owner_local,
                 };
             } else {
@@ -2570,7 +2633,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                     return LoweredExpr{
                         tyir::make_ty_expr(
-                            expr->span, tyir::LocalRef{node.head, use_kind}, local.ty),
+                            expr->span, tyir::LocalRef{node.head, use_kind}, local.ty,
+                            local.ct_available),
                         {},
                         local.ty.is_ref() ? local.borrowed_local : std::nullopt,
                     };
@@ -2631,6 +2695,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     cstc::symbol::Symbol, cstc::span::SourceSpan, cstc::symbol::SymbolHash>
                     seen_fields;
                 seen_fields.reserve(node.fields.size());
+                bool fields_ct_available = true;
 
                 for (const ast::StructInitField& field : node.fields) {
                     auto expected_ty = ctx.env.field_ty(type_name, field.name);
@@ -2664,6 +2729,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                             + "', found '" + val->expr->ty.display() + "'");
 
                     append_temp_borrows(temp_borrows, std::move(val->temp_borrows));
+                    fields_ct_available =
+                        fields_ct_available && expr_value_is_ct_available(val->expr);
 
                     lowered_fields.push_back(
                         tyir::TyStructInitField{field.name, std::move(val->expr), field.span});
@@ -2688,7 +2755,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         tyir::TyStructInit{
                             type_name, std::move(lowered_generic_args), std::move(lowered_fields)},
-                        result_ty),
+                        result_ty, fields_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -2712,10 +2779,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             temp_borrows.push_back(*place->owner_local);
                         }
                         const tyir::Ty ref_ty = tyir::ty::ref(place->expr->ty);
+                        const bool borrow_ct_available = expr_value_is_ct_available(place->expr);
 
                         return LoweredExpr{
                             tyir::make_ty_expr(
-                                expr->span, tyir::TyBorrow{std::move(place->expr)}, ref_ty),
+                                expr->span, tyir::TyBorrow{std::move(place->expr)}, ref_ty,
+                                borrow_ct_available),
                             std::move(temp_borrows),
                             place->owner_local,
                         };
@@ -2726,19 +2795,22 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(rhs.error()));
 
                     if (rhs->expr->ty.is_never()) {
+                        const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
                         return LoweredExpr{
                             tyir::make_ty_expr(
-                                expr->span, tyir::TyBorrow{std::move(rhs->expr)},
-                                tyir::ty::never()),
+                                expr->span, tyir::TyBorrow{std::move(rhs->expr)}, tyir::ty::never(),
+                                borrow_ct_available),
                             std::move(rhs->temp_borrows),
                             std::nullopt,
                         };
                     }
                     const tyir::Ty ref_ty = tyir::ty::ref(rhs->expr->ty);
+                    const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
 
                     return LoweredExpr{
                         tyir::make_ty_expr(
-                            expr->span, tyir::TyBorrow{std::move(rhs->expr)}, ref_ty),
+                            expr->span, tyir::TyBorrow{std::move(rhs->expr)}, ref_ty,
+                            borrow_ct_available),
                         std::move(rhs->temp_borrows),
                         std::nullopt,
                     };
@@ -2768,9 +2840,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         result_ty = unary_result_type(rhs->expr->ty, tyir::ty::bool_());
                     }
 
+                    const bool unary_ct_available = expr_value_is_ct_available(rhs->expr);
                     auto lowered = LoweredExpr{
                         tyir::make_ty_expr(
-                            expr->span, tyir::TyUnary{node.op, std::move(rhs->expr)}, result_ty),
+                            expr->span, tyir::TyUnary{node.op, std::move(rhs->expr)}, result_ty,
+                            unary_ct_available),
                         {},
                         std::nullopt,
                     };
@@ -2858,11 +2932,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     result_ty = binary_result_type(lhs->expr->ty, rhs->expr->ty, tyir::ty::bool_());
                     break;
                 }
+                const bool binary_ct_available =
+                    expr_value_is_ct_available(lhs->expr) && expr_value_is_ct_available(rhs->expr);
                 auto lowered = LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyBinary{node.op, std::move(lhs->expr), std::move(rhs->expr)},
-                        std::move(result_ty)),
+                        std::move(result_ty), binary_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -2886,11 +2962,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 const auto* access = std::get_if<tyir::TyFieldAccess>(&place->expr->node);
                 assert(access != nullptr);
+                const bool field_ct_available = expr_value_is_ct_available(place->expr);
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{access->base, access->field, tyir::ValueUseKind::Copy},
-                        place->expr->ty),
+                        place->expr->ty, field_ct_available),
                     {},
                     place->expr->ty.is_ref() ? place->owner_local : std::nullopt,
                 };
@@ -3047,20 +3124,22 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
+                    const bool call_ct_available = all_exprs_ct_available(lowered_args);
 
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyCall{
                             fn_name, std::move(concrete_generic_args), std::move(lowered_args)},
-                        lifted_return_ty);
+                        lifted_return_ty, call_ct_available);
                 } else {
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
+                    const bool call_ct_available = all_exprs_ct_available(lowered_args);
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyDeferredGenericCall{
                             fn_name, std::move(resolved_generic_args), std::move(lowered_args)},
-                        lifted_return_ty);
+                        lifted_return_ty, call_ct_available);
                 }
 
                 auto lowered = LoweredExpr{
@@ -3091,7 +3170,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty),
+                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty, false),
                     {},
                     std::nullopt,
                 };
@@ -3104,8 +3183,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     return std::unexpected(std::move(block.error()));
                 tyir::Ty block_ty = block->ty;
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
+                const bool block_ct_available = block_ptr->ct_available;
                 return LoweredExpr{
-                    tyir::make_ty_expr(expr->span, std::move(block_ptr), block_ty),
+                    tyir::make_ty_expr(
+                        expr->span, std::move(block_ptr), block_ty, block_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -3132,6 +3213,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 const bool then_reaches_join = block_can_fallthrough(*then_ptr);
 
                 tyir::Ty result_ty = then_ptr->ty;
+                const bool condition_ct_available = expr_value_is_ct_available(cond->expr);
+                bool if_ct_available = condition_ct_available && then_ptr->ct_available;
 
                 std::optional<tyir::TyExprPtr> else_branch;
                 if (node.else_branch.has_value()) {
@@ -3165,6 +3248,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     if (expr_can_fallthrough(*else_val->expr))
                         ctx.scope.merge_from(else_ctx.scope);
 
+                    if_ct_available = if_ct_available && expr_value_is_ct_available(else_val->expr);
                     else_branch = std::move(else_val->expr);
                 } else {
                     // No else branch: result type is Unit
@@ -3186,7 +3270,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         tyir::TyIf{
                             std::move(cond->expr), std::move(then_ptr), std::move(else_branch)},
-                        result_ty),
+                        result_ty, if_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -3205,6 +3289,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 //   - bare break     → Unit
                 //   - break expr     → expr type
                 const tyir::Ty loop_ty = ctx.current_loop().break_ty.value_or(tyir::ty::never());
+                const bool loop_ct_available = ctx.current_loop().break_ct_available.value_or(true);
                 if (loop_ty.is_ref()) {
                     ctx.pop_loop();
                     return make_error(expr->span, "loop expressions cannot yield references yet");
@@ -3212,7 +3297,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
                 return LoweredExpr{
-                    tyir::make_ty_expr(expr->span, tyir::TyLoop{std::move(body_ptr)}, loop_ty),
+                    tyir::make_ty_expr(
+                        expr->span, tyir::TyLoop{std::move(body_ptr)}, loop_ty, loop_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -3232,6 +3318,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                                   + cond->expr->ty.display() + "'");
                 }
                 release_temp_borrows(ctx, cond->temp_borrows);
+                const bool condition_ct_available = expr_value_is_ct_available(cond->expr);
 
                 ctx.push_loop(LoopKind::While);
                 auto body = lower_block(*node.body, ctx);
@@ -3241,11 +3328,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
+                const bool while_ct_available = condition_ct_available && body_ptr->ct_available;
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span, tyir::TyWhile{std::move(cond->expr), std::move(body_ptr)},
-                        tyir::ty::unit()),
+                        tyir::ty::unit(), while_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -3257,6 +3345,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 ctx.scope.push();
 
                 std::optional<tyir::TyForInit> lowered_init;
+                bool for_ct_available = true;
 
                 if (node.init.has_value()) {
                     const auto& init_var = *node.init;
@@ -3267,6 +3356,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             return std::unexpected(std::move(init_expr.error()));
                         }
                         tyir::Ty init_ty;
+                        bool init_ct_available = true;
                         if (init_let->type_annotation.has_value()) {
                             auto ann = lower_type(
                                 *init_let->type_annotation, ctx.env, init_let->span,
@@ -3309,8 +3399,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 return std::unexpected(std::move(ct_check.error()));
                             }
                             init_ty = *ann;
+                            init_ct_available = expr_value_is_ct_available(init_expr->expr);
                         } else {
                             init_ty = init_expr->expr->ty;
+                            init_ct_available = expr_value_is_ct_available(init_expr->expr);
                         }
 
                         std::optional<std::size_t> borrowed_local;
@@ -3319,13 +3411,15 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             consume_temp_borrow(init_expr->temp_borrows, borrowed_local.value());
                         }
                         if (!init_let->discard && init_let->name.is_valid()
-                            && !ctx.scope.insert(init_let->name, init_ty, borrowed_local)) {
+                            && !ctx.scope.insert(
+                                init_let->name, init_ty, borrowed_local, init_ct_available)) {
                             ctx.scope.pop();
                             return make_error(
                                 init_let->span, "duplicate local binding '"
                                                     + std::string(init_let->name.as_str()) + "'");
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
+                        for_ct_available = for_ct_available && init_ct_available;
                         lowered_init = tyir::TyForInit{
                             init_let->discard, init_let->name, init_ty, std::move(init_expr->expr),
                             init_let->span};
@@ -3338,6 +3432,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             return std::unexpected(std::move(init_expr.error()));
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
+                        for_ct_available =
+                            for_ct_available && expr_value_is_ct_available(init_expr->expr);
                         // Treat as a discard init — wrap in TyForInit with discard=true
                         lowered_init = tyir::TyForInit{
                             true, cstc::symbol::kInvalidSymbol, init_expr->expr->ty,
@@ -3362,6 +3458,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 + cond->expr->ty.display() + "'");
                     }
                     release_temp_borrows(ctx, cond->temp_borrows);
+                    for_ct_available = for_ct_available && expr_value_is_ct_available(cond->expr);
                     lowered_cond = std::move(cond->expr);
                 }
 
@@ -3376,6 +3473,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 loop_ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
+                for_ct_available = for_ct_available && body_ptr->ct_available;
 
                 std::optional<tyir::TyExprPtr> lowered_step;
                 if (node.step.has_value()) {
@@ -3385,6 +3483,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(step.error()));
                     }
                     release_temp_borrows(loop_ctx, step->temp_borrows);
+                    for_ct_available = for_ct_available && expr_value_is_ct_available(step->expr);
                     lowered_step = std::move(step->expr);
                 }
 
@@ -3396,7 +3495,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         tyir::TyFor{
                             std::move(lowered_init), std::move(lowered_cond),
                             std::move(lowered_step), std::move(body_ptr)},
-                        tyir::ty::unit()),
+                        tyir::ty::unit(), for_ct_available),
                     {},
                     std::nullopt,
                 };
@@ -3429,14 +3528,18 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     // Re-acquire the reference after recursion.
                     auto& loop_ctx = ctx.current_loop();
                     const tyir::Ty& val_ty = val->expr->ty;
+                    const bool break_ct_available = expr_value_is_ct_available(val->expr);
                     if (!loop_ctx.break_ty.has_value()) {
                         loop_ctx.break_ty = val_ty;
+                        loop_ctx.break_ct_available = break_ct_available;
                     } else {
                         const tyir::Ty& prev = *loop_ctx.break_ty;
                         auto joined = join_loop_break_types(prev, val_ty, expr->span, ctx);
                         if (!joined)
                             return std::unexpected(std::move(joined.error()));
                         loop_ctx.break_ty = *joined;
+                        loop_ctx.break_ct_available =
+                            loop_ctx.break_ct_available.value_or(true) && break_ct_available;
                     }
 
                     release_temp_borrows(ctx, val->temp_borrows);
@@ -3454,6 +3557,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     // Bare break in `loop` contributes Unit
                     if (!loop_ctx.break_ty.has_value()) {
                         loop_ctx.break_ty = tyir::ty::unit();
+                        loop_ctx.break_ct_available = true;
                     } else {
                         const tyir::Ty& prev = *loop_ctx.break_ty;
                         auto joined =
@@ -3461,6 +3565,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         if (!joined)
                             return std::unexpected(std::move(joined.error()));
                         loop_ctx.break_ty = *joined;
+                        loop_ctx.break_ct_available = loop_ctx.break_ct_available.value_or(true);
                     }
                 }
                 // Bare break in while/for: no type tracking needed
@@ -3524,8 +3629,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
             return make_error(expr->span, "unsupported expression kind");
         },
         expr->node);
-    if (lowered.has_value())
+    if (lowered.has_value()) {
+        lowered->expr->ct_available =
+            value_is_ct_available(lowered->expr->ct_available, lowered->expr->ty);
         lowered->deferred_generic_probe_validation = ctx.defer_generic_probe_validation;
+    }
     return lowered;
 }
 
@@ -3550,7 +3658,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
     };
     ctx.scope.push();
     for (const tyir::TyParam& p : ty_params) {
-        if (!ctx.scope.insert(p.name, p.ty))
+        if (!ctx.scope.insert(p.name, p.ty, std::nullopt, p.requires_ct()))
             return make_error(p.span, "duplicate parameter '" + std::string(p.name.as_str()) + "'");
     }
 
@@ -3565,6 +3673,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
             return std::unexpected(std::move(resolved_tail.error()));
         body->tail = std::move(*resolved_tail);
         body->ty = block_can_fallthrough(*body) ? (*body->tail)->ty : tyir::ty::never();
+        body->ct_available =
+            value_is_ct_available(expr_value_is_ct_available(*body->tail), body->ty);
     }
 
     // Check that body type matches declared return type (when a tail is present)

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -28,6 +28,7 @@ using tyir::matches_type_shape;
 /// Signature stored for each top-level function.
 struct FnSignature {
     std::vector<tyir::Ty> param_types;
+    std::vector<tyir::ParamRequirement> param_requirements;
     tyir::Ty return_ty;
     cstc::span::SourceSpan span;
     std::vector<cstc::ast::GenericParam> generic_params;
@@ -1358,6 +1359,9 @@ struct LoweredPlace {
         if (!pt)
             return std::unexpected(std::move(pt.error()));
         sig.param_types.push_back(*pt);
+        sig.param_requirements.push_back(
+            p.type.requires_ct ? tyir::ParamRequirement::CtRequired
+                               : tyir::ParamRequirement::RuntimeAllowed);
     }
     return sig;
 }
@@ -3463,7 +3467,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
     ty_params.reserve(fn.params.size());
     for (std::size_t i = 0; i < fn.params.size(); ++i)
         ty_params.push_back(
-            tyir::TyParam{fn.params[i].name, sig.param_types[i], fn.params[i].span});
+            tyir::TyParam{
+                fn.params[i].name, sig.param_types[i], fn.params[i].span,
+                sig.param_requirements[i]});
 
     LowerCtx ctx{
         env, {}, make_generic_param_set(fn.generic_params), false, sig.return_ty, {},
@@ -3782,6 +3788,7 @@ std::expected<tyir::TyProgram, LowerError> lower_program(const ast::Program& pro
                         .name = ext_fn->params[i].name,
                         .ty = sig.param_types[i],
                         .span = ext_fn->params[i].span,
+                        .requirement = sig.param_requirements[i],
                     });
             }
             result.items.push_back(std::move(ty_decl));

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -944,8 +944,7 @@ struct LowerCtx {
 
     return make_error(
         span, "argument " + param_name + " must be compile-time available: expected '"
-                  + ct_required_type_display(expected_ty) + "', found '" + arg->ty.display()
-                  + "'");
+                  + ct_required_type_display(expected_ty) + "', found '" + arg->ty.display() + "'");
 }
 
 [[nodiscard]] static std::expected<void, LowerError> require_ct_annotation_value(

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -384,13 +384,14 @@ static void test_ct_required_param_rejects_runtime_block_argument() {
     must_fail_with_message(
         "fn reserve(count: const num) -> num { count }"
         "fn main() -> runtime num { reserve(runtime { 1 }) }",
-        "argument `count` must be compile-time available");
+        "argument `count` must be compile-time available: expected 'const num', found 'runtime "
+        "num'");
 }
 
 static void test_ct_required_let_annotation_rejects_runtime_value() {
     must_fail_with_message(
         "fn main() -> runtime num { let count: const num = runtime { 1 }; count }",
-        "let binding must be compile-time available");
+        "let binding must be compile-time available: expected 'const num', found 'runtime num'");
 }
 
 static void test_ct_required_param_rejects_forwarded_runtime_allowed_param() {
@@ -410,7 +411,7 @@ static void test_ct_required_param_rejects_forwarded_runtime_allowed_local() {
 static void test_ct_required_let_annotation_rejects_runtime_allowed_param() {
     must_fail_with_message(
         "fn wrap(count: num) -> num { let forwarded: const num = count; forwarded }",
-        "let binding must be compile-time available");
+        "let binding must be compile-time available: expected 'const num', found 'num'");
 }
 
 static void test_fn_preserves_generic_metadata() {

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -393,6 +393,26 @@ static void test_ct_required_let_annotation_rejects_runtime_value() {
         "let binding must be compile-time available");
 }
 
+static void test_ct_required_param_rejects_forwarded_runtime_allowed_param() {
+    must_fail_with_message(
+        "fn reserve(count: !runtime num) -> num { count }"
+        "fn wrap(count: num) -> num { reserve(count) }",
+        "argument `count` must be compile-time available");
+}
+
+static void test_ct_required_param_rejects_forwarded_runtime_allowed_local() {
+    must_fail_with_message(
+        "fn reserve(count: !runtime num) -> num { count }"
+        "fn wrap(count: num) -> num { let forwarded = count; reserve(forwarded) }",
+        "argument `count` must be compile-time available");
+}
+
+static void test_ct_required_let_annotation_rejects_runtime_allowed_param() {
+    must_fail_with_message(
+        "fn wrap(count: num) -> num { let forwarded: const num = count; forwarded }",
+        "let binding must be compile-time available");
+}
+
 static void test_fn_preserves_generic_metadata() {
     const auto prog =
         must_lower_with_constraint_prelude("fn id<T>(value: T) -> T where true, 1 == 1 { value }");
@@ -946,6 +966,9 @@ int main() {
     test_ct_required_param_rejects_runtime_argument();
     test_ct_required_param_rejects_runtime_block_argument();
     test_ct_required_let_annotation_rejects_runtime_value();
+    test_ct_required_param_rejects_forwarded_runtime_allowed_param();
+    test_ct_required_param_rejects_forwarded_runtime_allowed_local();
+    test_ct_required_let_annotation_rejects_runtime_allowed_param();
     test_fn_preserves_generic_metadata();
     test_fn_where_clause_rejects_parameter_references();
     test_fn_decl_where_clause_allows_parameter_references_in_decl_probe();

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -364,6 +364,14 @@ static void test_runtime_fn_return_uses_runtime_sugar() {
     assert(fn.body->ty.is_runtime);
 }
 
+static void test_ct_required_param_requirement_is_preserved() {
+    const auto prog = must_lower("fn reserve(count: !runtime num) -> num { count }");
+    const auto& fn = std::get<TyFnDecl>(prog.items[0]);
+    assert(fn.params.size() == 1);
+    assert(fn.params[0].ty == ty::num());
+    assert(fn.params[0].requires_ct());
+}
+
 static void test_fn_preserves_generic_metadata() {
     const auto prog =
         must_lower_with_constraint_prelude("fn id<T>(value: T) -> T where true, 1 == 1 { value }");
@@ -913,6 +921,7 @@ int main() {
     test_fn_ref_return_rejected();
     test_runtime_fn_preserves_runtime_markers();
     test_runtime_fn_return_uses_runtime_sugar();
+    test_ct_required_param_requirement_is_preserved();
     test_fn_preserves_generic_metadata();
     test_fn_where_clause_rejects_parameter_references();
     test_fn_decl_where_clause_allows_parameter_references_in_decl_probe();

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -401,6 +401,23 @@ static void test_ct_required_param_rejects_forwarded_runtime_allowed_param() {
         "argument `count` must be compile-time available");
 }
 
+static void test_ct_required_param_rejects_invalid_name_with_argument_number() {
+    auto ast = cstc::parser::parse_source(
+        "fn reserve(count: const num) { }"
+        "runtime fn source() -> num { 1 }"
+        "fn main() { reserve(source()); }");
+    assert(ast.has_value());
+    auto& reserve = std::get<cstc::ast::FnDecl>(ast->items[0]);
+    reserve.params[0].name = kInvalidSymbol;
+
+    const auto tyir = lower_program(*ast);
+    assert(!tyir.has_value());
+    assert(
+        tyir.error().message.find("argument 1 must be compile-time available")
+        != std::string::npos);
+    assert(tyir.error().message.find("argument argument") == std::string::npos);
+}
+
 static void test_ct_required_param_rejects_forwarded_runtime_allowed_local() {
     must_fail_with_message(
         "fn reserve(count: !runtime num) -> num { count }"
@@ -968,6 +985,7 @@ int main() {
     test_ct_required_param_rejects_runtime_block_argument();
     test_ct_required_let_annotation_rejects_runtime_value();
     test_ct_required_param_rejects_forwarded_runtime_allowed_param();
+    test_ct_required_param_rejects_invalid_name_with_argument_number();
     test_ct_required_param_rejects_forwarded_runtime_allowed_local();
     test_ct_required_let_annotation_rejects_runtime_allowed_param();
     test_fn_preserves_generic_metadata();

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -372,6 +372,27 @@ static void test_ct_required_param_requirement_is_preserved() {
     assert(fn.params[0].requires_ct());
 }
 
+static void test_ct_required_param_rejects_runtime_argument() {
+    must_fail_with_message(
+        "runtime fn source() -> num { 1 }"
+        "fn reserve(count: !runtime num) -> num { count }"
+        "fn main() -> runtime num { reserve(source()) }",
+        "argument `count` must be compile-time available");
+}
+
+static void test_ct_required_param_rejects_runtime_block_argument() {
+    must_fail_with_message(
+        "fn reserve(count: const num) -> num { count }"
+        "fn main() -> runtime num { reserve(runtime { 1 }) }",
+        "argument `count` must be compile-time available");
+}
+
+static void test_ct_required_let_annotation_rejects_runtime_value() {
+    must_fail_with_message(
+        "fn main() -> runtime num { let count: const num = runtime { 1 }; count }",
+        "let binding must be compile-time available");
+}
+
 static void test_fn_preserves_generic_metadata() {
     const auto prog =
         must_lower_with_constraint_prelude("fn id<T>(value: T) -> T where true, 1 == 1 { value }");
@@ -922,6 +943,9 @@ int main() {
     test_runtime_fn_preserves_runtime_markers();
     test_runtime_fn_return_uses_runtime_sugar();
     test_ct_required_param_requirement_is_preserved();
+    test_ct_required_param_rejects_runtime_argument();
+    test_ct_required_param_rejects_runtime_block_argument();
+    test_ct_required_let_annotation_rejects_runtime_value();
     test_fn_preserves_generic_metadata();
     test_fn_where_clause_rejects_parameter_references();
     test_fn_decl_where_clause_allows_parameter_references_in_decl_probe();

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -254,6 +254,20 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
 }
 
+[[nodiscard]] static bool type_has_runtime_dependency(const tyir::Ty& ty) {
+    if (ty.is_runtime)
+        return true;
+    if (ty.kind == tyir::TyKind::Ref)
+        return ty.pointee != nullptr && type_has_runtime_dependency(*ty.pointee);
+    if (ty.kind != tyir::TyKind::Named)
+        return false;
+    for (const tyir::Ty& arg : ty.generic_args) {
+        if (type_has_runtime_dependency(arg))
+            return true;
+    }
+    return false;
+}
+
 [[nodiscard]] static bool call_argument_may_be_compatible_after_substitution(
     const tyir::Ty& actual, const tyir::Ty& expected, const GenericParamSet& generic_params) {
     return types_may_be_compatible_after_substitution(
@@ -1837,6 +1851,14 @@ ConstraintEvalResult evaluate_constraint(
                                     std::nullopt,
                                 };
                             }
+                            if (fn.params[index].requires_ct()
+                                && type_has_runtime_dependency(node.args[index]->ty)) {
+                                return {
+                                    ConstraintEvalKind::Unsatisfied,
+                                    "probed expression is not type-valid",
+                                    std::nullopt,
+                                };
+                            }
                         }
                         if (!generic_args_depend) {
                             auto status = enforce_constraints(
@@ -1884,6 +1906,14 @@ ConstraintEvalResult evaluate_constraint(
                                     unresolved.has_value()) {
                                     return *unresolved;
                                 }
+                                return {
+                                    ConstraintEvalKind::Unsatisfied,
+                                    "probed expression is not type-valid",
+                                    std::nullopt,
+                                };
+                            }
+                            if (decl.params[index].requires_ct()
+                                && type_has_runtime_dependency(node.args[index]->ty)) {
                                 return {
                                     ConstraintEvalKind::Unsatisfied,
                                     "probed expression is not type-valid",

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -12,6 +12,7 @@ namespace cstc::tyir_interp::detail {
 using tyir::common_type;
 using tyir::compatible;
 using tyir::matches_type_shape;
+using tyir::type_has_runtime_dependency;
 
 ValuePtr make_num(double value) {
     auto out = std::make_shared<Value>();
@@ -252,20 +253,6 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 [[nodiscard]] static bool
     call_argument_compatible(const tyir::Ty& actual, const tyir::Ty& expected) {
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
-}
-
-[[nodiscard]] static bool type_has_runtime_dependency(const tyir::Ty& ty) {
-    if (ty.is_runtime)
-        return true;
-    if (ty.kind == tyir::TyKind::Ref)
-        return ty.pointee != nullptr && type_has_runtime_dependency(*ty.pointee);
-    if (ty.kind != tyir::TyKind::Named)
-        return false;
-    for (const tyir::Ty& arg : ty.generic_args) {
-        if (type_has_runtime_dependency(arg))
-            return true;
-    }
-    return false;
 }
 
 [[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -268,6 +268,10 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
     return false;
 }
 
+[[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
+    return expr != nullptr && expr->ct_available && !type_has_runtime_dependency(expr->ty);
+}
+
 [[nodiscard]] static bool call_argument_may_be_compatible_after_substitution(
     const tyir::Ty& actual, const tyir::Ty& expected, const GenericParamSet& generic_params) {
     return types_may_be_compatible_after_substitution(
@@ -1162,6 +1166,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
     auto rewritten = std::make_shared<tyir::TyBlock>();
     rewritten->ty = apply_substitution(block->ty, subst);
     rewritten->span = block->span;
+    rewritten->ct_available = block->ct_available && !type_has_runtime_dependency(rewritten->ty);
     rewritten->stmts.reserve(block->stmts.size());
     for (const tyir::TyStmt& stmt : block->stmts) {
         rewritten->stmts.push_back(
@@ -1193,7 +1198,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
         return nullptr;
 
     const tyir::Ty rewritten_ty = apply_substitution(expr->ty, subst);
-    return std::visit(
+    auto rewritten_expr = std::visit(
         [&](const auto& node) -> tyir::TyExprPtr {
             using Node = std::decay_t<decltype(node)>;
             if constexpr (
@@ -1332,6 +1337,8 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
             }
         },
         expr->node);
+    rewritten_expr->ct_available = expr->ct_available && !type_has_runtime_dependency(rewritten_ty);
+    return rewritten_expr;
 }
 
 [[nodiscard]] static std::string format_num(double value) {
@@ -1852,7 +1859,7 @@ ConstraintEvalResult evaluate_constraint(
                                 };
                             }
                             if (fn.params[index].requires_ct()
-                                && type_has_runtime_dependency(node.args[index]->ty)) {
+                                && !expr_value_is_ct_available(node.args[index])) {
                                 return {
                                     ConstraintEvalKind::Unsatisfied,
                                     "probed expression is not type-valid",
@@ -1913,7 +1920,7 @@ ConstraintEvalResult evaluate_constraint(
                                 };
                             }
                             if (decl.params[index].requires_ct()
-                                && type_has_runtime_dependency(node.args[index]->ty)) {
+                                && !expr_value_is_ct_available(node.args[index])) {
                                 return {
                                     ConstraintEvalKind::Unsatisfied,
                                     "probed expression is not type-valid",

--- a/test/e2e/fail_compile/generics/ct_required_generic_runtime_argument.cst
+++ b/test/e2e/fail_compile/generics/ct_required_generic_runtime_argument.cst
@@ -1,0 +1,9 @@
+runtime fn source() -> num { 1 }
+
+fn static_id<T>(value: const T) -> T {
+    value
+}
+
+fn main() -> runtime num {
+    static_id(source())
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_forwarded_local.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_forwarded_local.cst
@@ -1,0 +1,14 @@
+runtime fn source() -> num { 1 }
+
+fn reserve(count: !runtime num) -> num {
+    count
+}
+
+fn wrap(count: num) -> num {
+    let forwarded = count;
+    reserve(forwarded)
+}
+
+fn main() -> runtime num {
+    wrap(source())
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_forwarded_local_annotation.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_forwarded_local_annotation.cst
@@ -1,0 +1,10 @@
+runtime fn source() -> num { 1 }
+
+fn wrap(count: num) -> num {
+    let forwarded: const num = count;
+    forwarded
+}
+
+fn main() -> runtime num {
+    wrap(source())
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_forwarded_parameter.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_forwarded_parameter.cst
@@ -1,0 +1,13 @@
+runtime fn source() -> num { 1 }
+
+fn reserve(count: !runtime num) -> num {
+    count
+}
+
+fn wrap(count: num) -> num {
+    reserve(count)
+}
+
+fn main() -> runtime num {
+    wrap(source())
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_local_annotation.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_local_annotation.cst
@@ -1,0 +1,4 @@
+fn main() -> runtime num {
+    let count: const num = runtime { 1 };
+    count
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_nested_qualifier.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_nested_qualifier.cst
@@ -1,0 +1,5 @@
+fn view(value: &!runtime num) -> &num {
+    value
+}
+
+fn main() {}

--- a/test/e2e/fail_compile/type_errors/ct_required_runtime_block.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_runtime_block.cst
@@ -1,0 +1,7 @@
+fn reserve(count: !runtime num) -> num {
+    count
+}
+
+fn main() -> runtime num {
+    reserve(runtime { 1 })
+}

--- a/test/e2e/fail_compile/type_errors/ct_required_runtime_result.cst
+++ b/test/e2e/fail_compile/type_errors/ct_required_runtime_result.cst
@@ -1,0 +1,9 @@
+runtime fn source() -> num { 1 }
+
+fn reserve(count: !runtime num) -> num {
+    count
+}
+
+fn main() -> runtime num {
+    reserve(source())
+}

--- a/test/e2e/pass/runtime/ct_required_parameters.cst
+++ b/test/e2e/pass/runtime/ct_required_parameters.cst
@@ -1,0 +1,23 @@
+runtime fn source() -> num { 40 }
+
+fn add(a: num, b: num) -> num {
+    a + b
+}
+
+fn reserve(count: !runtime num, extra: const num) -> num {
+    add(count, extra)
+}
+
+fn static_id<T>(value: const T) -> T {
+    value
+}
+
+fn main() {
+    let reserved: num = reserve(20, 2);
+    let generic_reserved: num = static_id(5);
+    let lifted: runtime num = add(source(), 2);
+
+    assert_eq(reserved, 22);
+    assert_eq(generic_reserved, 5);
+    let _ = lifted;
+}


### PR DESCRIPTION
Part of implementation for #54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for compile-time parameter requirements via `!runtime` and `const` type annotations so callers can require arguments be compile-time-available.
* **Improvements**
  * Internal IR now tracks compile-time availability so tooling and diagnostics reflect CT vs runtime constraints.
  * Type printing shows `!runtime` for parameters that require compile-time availability; errors are clearer when CT constraints are violated.
* **Tests**
  * Added parser, lowering, TYIR, interpreter, and end-to-end tests covering `!runtime`/`const` semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->