### PR TITLE
feat: enhance diagnostics and testing for availability evidence coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(CICEST_BUILD_TESTS)
     enable_testing()
     if(CICEST_BUILD_E2E_TESTS)
         add_subdirectory(test/e2e)
+        add_subdirectory(test/availability_evidence)
     endif()
 endif()
 

--- a/compiler/cstc_tyir_builder/README.md
+++ b/compiler/cstc_tyir_builder/README.md
@@ -101,7 +101,7 @@ Common errors:
 | Type mismatch in let | `"type mismatch in let binding: expected 'num', found 'bool'"` |
 | Wrong argument count | `"function 'f' expects 2 argument(s), 1 provided"` |
 | Argument type mismatch | `"argument 1 of 'f': expected 'num', found 'bool'"` |
-| Return type mismatch | `"function 'f' body has type 'bool' but return type is 'num'"` |
+| Return type mismatch | `"function 'f' body type mismatch: expected 'num', found 'bool'"` |
 | Non-bool condition | `"'if' condition must have type 'bool', found 'num'"` |
 | Field not found | `"no field 'z' in struct 'Point'"` |
 | Duplicate top-level declaration | `"duplicate function name 'main'"` |

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -3668,10 +3668,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
     if (body->tail.has_value() && !compatible(body->ty, sig.return_ty)
         && !should_defer_generic_probe_failure(body->ty, sig.return_ty, ctx))
         return make_error(
-            fn.body->span, "function '" + display_decl_name(fn) + "' body has type '"
-                               + body->ty.display() + "' but return type is '"
-                               + sig.return_ty.display() + "': expected '" + sig.return_ty.display()
-                               + "', found '" + body->ty.display() + "'");
+            fn.body->span, "function '" + display_decl_name(fn) + "' body type mismatch: expected '"
+                               + sig.return_ty.display() + "', found '" + body->ty.display() + "'");
 
     // Non-Unit functions without a tail expression must not reach the end of
     // the body without returning.

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -3670,7 +3670,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
         return make_error(
             fn.body->span, "function '" + display_decl_name(fn) + "' body has type '"
                                + body->ty.display() + "' but return type is '"
-                               + sig.return_ty.display() + "'");
+                               + sig.return_ty.display() + "': expected '" + sig.return_ty.display()
+                               + "', found '" + body->ty.display() + "'");
 
     // Non-Unit functions without a tail expression must not reach the end of
     // the body without returning.

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -471,7 +471,7 @@ static void test_fn_decl_where_clause_allows_parameter_references_in_decl_probe(
 static void test_decl_probe_does_not_relax_matching_body_checks() {
     must_fail_with_constraint_prelude(
         "fn bad<T>(value: T) -> num where decl(value) { value }",
-        "function 'bad' body has type 'T' but return type is 'num'");
+        "function 'bad' body type mismatch: expected 'num', found 'T'");
 }
 
 static void test_decl_probe_inside_disjunction_does_not_relax_matching_body_checks() {
@@ -814,7 +814,7 @@ static void test_runtime_return_annotation_accepts_plain_value() {
 static void test_runtime_return_type_mismatch_rejected() {
     must_fail_with_message(
         "struct Job; fn unwrap(job: runtime Job) -> Job { job }",
-        "body has type 'runtime Job' but return type is 'Job'");
+        "body type mismatch: expected 'Job', found 'runtime Job'");
 }
 
 static void test_runtime_main_return_allowed() {
@@ -887,7 +887,7 @@ static void test_fn_never_return_type_valid() {
 }
 
 static void test_fn_never_return_type_mismatch() {
-    must_fail_with_message("fn f() -> ! { 42 }", "body has type 'num' but return type is '!'");
+    must_fail_with_message("fn f() -> ! { 42 }", "body type mismatch: expected '!', found 'num'");
 }
 
 // ─── main return type constraints ─────────────────────────────────────────────

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -466,7 +466,7 @@ static void test_if_else_runtime_join_prevents_demotion() {
     must_fail_with_message(
         "fn choose(flag: bool) -> num { if flag { 1 } else { source() } }"
         "runtime fn source() -> num { 2 }",
-        "body has type 'runtime num' but return type is 'num'");
+        "expected 'num', found 'runtime num'");
 }
 
 // ─── Control flow ─────────────────────────────────────────────────────────────

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -246,7 +246,7 @@ static void test_plain_call_lifted_result_still_prevents_return_demotion() {
         "runtime fn source() -> num { 1 }"
         "fn sink(value: num) -> num { value }"
         "fn main() -> num { sink(source()) }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 static void test_plain_call_lifts_runtime_arguments() {
@@ -278,7 +278,7 @@ static void test_runtime_argument_demotion_error() {
         "runtime fn source() -> num { 1 }"
         "fn sink(value: num) -> num { value }"
         "fn main() -> num { sink(source()) }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 static void test_plain_generic_call_accepts_runtime_argument_and_lifts_result() {
@@ -335,14 +335,14 @@ static void test_runtime_arithmetic_preserves_runtime_type() {
 static void test_runtime_arithmetic_prevents_demotion() {
     must_fail_with_message(
         "fn f() -> num { source() + 1 } runtime fn source() -> num { 1 }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 static void test_runtime_deferred_generic_return_prevents_demotion() {
     must_fail_with_message(
         "runtime fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn f() -> num { make_default(true) }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 static void test_runtime_comparison_preserves_runtime_type() {
@@ -366,7 +366,7 @@ static void test_runtime_logical_preserves_runtime_type() {
 static void test_runtime_logical_prevents_demotion() {
     must_fail_with_message(
         "fn f() -> bool { flag() && true } runtime fn flag() -> bool { true }",
-        "body has type 'runtime bool' but return type is 'bool'");
+        "body type mismatch: expected 'bool', found 'runtime bool'");
 }
 
 static void test_runtime_block_promotes_pure_result() {
@@ -379,7 +379,8 @@ static void test_runtime_block_promotes_pure_result() {
 
 static void test_runtime_block_prevents_demotion() {
     must_fail_with_message(
-        "fn f() -> num { runtime { 1 } }", "body has type 'runtime num' but return type is 'num'");
+        "fn f() -> num { runtime { 1 } }",
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 // ─── Unary operators ─────────────────────────────────────────────────────────
@@ -638,7 +639,7 @@ static void test_loop_break_runtime_join_prevents_demotion() {
         "  }"
         "}"
         "runtime fn source() -> num { 2 }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 // ─── Break/continue outside loop ─────────────────────────────────────────────
@@ -1010,7 +1011,7 @@ static void test_if_branch_join_keeps_runtime_on_deferred_generic_call() {
     must_fail_with_message(
         "runtime fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn f(cond: bool) -> num { if cond { make_default(true) } else { 0 } }",
-        "body has type 'runtime num' but return type is 'num'");
+        "body type mismatch: expected 'num', found 'runtime num'");
 }
 
 static void test_expected_type_resolves_nested_deferred_generic_argument() {

--- a/test/availability_evidence/CMakeLists.txt
+++ b/test/availability_evidence/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_test(NAME availability_evidence
+    COMMAND ${CMAKE_COMMAND}
+        -DAVAILABILITY_EVIDENCE_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -DAVAILABILITY_EVIDENCE_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -DCICEST_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -DCSTC_BINARY=$<TARGET_FILE:cstc>
+        -DCSTC_INSPECT_BINARY=$<TARGET_FILE:cstc_inspect>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_availability_evidence.cmake
+)
+
+set_tests_properties(availability_evidence PROPERTIES
+    LABELS "availability;evidence"
+)

--- a/test/availability_evidence/README.md
+++ b/test/availability_evidence/README.md
@@ -1,0 +1,15 @@
+# Availability Evidence Suite
+
+This suite checks paper-facing availability evidence through stable substring
+patterns rather than full TyIR golden files. Each `.patterns` file declares the
+source program with `# source:`, the rule shape with `# rule:`, and then ordered
+substrings that must appear in the produced output.
+
+TyIR specs run:
+
+```text
+cstc_inspect <source> --out-type tyir
+```
+
+Diagnostic specs compile the source and require compilation to fail, then check
+ordered substrings in compiler stderr.

--- a/test/availability_evidence/coverage_inventory.md
+++ b/test/availability_evidence/coverage_inventory.md
@@ -1,0 +1,20 @@
+# Availability Coverage Inventory
+
+This inventory maps availability rule shapes used in the paper to checked
+artifact evidence. `availability_evidence` entries are pattern specs run by the
+new inspection/diagnostic CTest target. `e2e` entries are existing compile/run
+tests that continue to run through the `e2e` CTest target.
+
+| Rule shape | Evidence | Notes |
+| --- | --- | --- |
+| Call-site lifting | `availability_evidence/tyir/availability_validation.patterns`; `test/e2e/pass/runtime/plain_call_lifting.cst`; `test/e2e/pass/runtime/plain_generic_call_lifting.cst` | Checks folded static calls and runtime-qualified residual calls. |
+| CT-required acceptance | `availability_evidence/tyir/ct_required_parameters.patterns`; `availability_evidence/tyir/availability_window_config.patterns` | Checks `!runtime` parameter display and folded CT calls. |
+| CT-required rejection | `availability_evidence/diagnostics/ct_required_runtime_result.patterns`; `test/e2e/fail_compile/generics/ct_required_generic_runtime_argument.cst` | Checks parameter-specific diagnostics with expected/found availability shapes. |
+| Runtime-result functions | `test/e2e/pass/runtime/runtime_result_function.cst` | Ensures explicit runtime result annotations remain accepted. |
+| Runtime block partial normalization | `availability_evidence/tyir/runtime_block_partial_normalization.patterns` | Checks a pure expression folded under an explicit `TyRuntimeBlock`. |
+| Runtime block dynamic calls | `test/e2e/pass/runtime/runtime_block_dynamic_call.cst`; `availability_evidence/tyir/availability_validation.patterns` | Checks runtime blocks with residual dynamic calls and independently folded arguments. |
+| Structural joins | `availability_evidence/tyir/runtime_join_promotion.patterns` | Checks a runtime-qualified `TyIf` with static and runtime branches. |
+| Rejected reverse demotion | `availability_evidence/diagnostics/runtime_join_demotion.patterns`; `test/e2e/fail_compile/type_errors/plain_call_runtime_return_demotion.cst` | Checks runtime-qualified values cannot flow into compile-time result positions. |
+| Compile-time assertion failure | `test/e2e/fail_compile/const_eval/availability_validation_assert.cst`; `test/e2e/fail_compile/const_eval/assert_false.cst` | Keeps compile-time assertion failures covered by negative e2e tests. |
+| Runtime assertion residualization | `test/e2e/pass/runtime/availability_validation.cst`; `test/e2e/pass/runtime/availability_window_config.cst` | Runtime-qualified calls through asserting helpers compile and remain runtime-residualized. |
+| Aggregate/generic lifting | `availability_evidence/tyir/availability_window_config.patterns`; `test/e2e/pass/runtime/availability_generic_config.cst` | Checks lifted generic constructors/helpers and aggregate runtime qualification. |

--- a/test/availability_evidence/diagnostics/ct_required_runtime_result.patterns
+++ b/test/availability_evidence/diagnostics/ct_required_runtime_result.patterns
@@ -1,0 +1,5 @@
+# source: test/e2e/fail_compile/type_errors/ct_required_runtime_result.cst
+# rule: ct_required_rejection
+argument `count` must be compile-time available
+expected 'const num'
+found 'runtime num'

--- a/test/availability_evidence/diagnostics/runtime_join_demotion.patterns
+++ b/test/availability_evidence/diagnostics/runtime_join_demotion.patterns
@@ -1,0 +1,5 @@
+# source: test/e2e/fail_compile/type_errors/runtime_join_demotion.cst
+# rule: rejected_reverse_demotion
+function 'main' body
+expected 'num'
+found 'runtime num'

--- a/test/availability_evidence/run_availability_evidence.cmake
+++ b/test/availability_evidence/run_availability_evidence.cmake
@@ -1,0 +1,142 @@
+cmake_minimum_required(VERSION 3.21)
+
+foreach(required_var IN ITEMS
+    AVAILABILITY_EVIDENCE_SOURCE_DIR
+    AVAILABILITY_EVIDENCE_BINARY_DIR
+    CICEST_SOURCE_DIR
+    CSTC_BINARY
+    CSTC_INSPECT_BINARY
+)
+    if(NOT DEFINED ${required_var} OR "${${required_var}}" STREQUAL "")
+        message(FATAL_ERROR "Missing required variable ${required_var}")
+    endif()
+endforeach()
+
+function(read_pattern_spec spec_path)
+    set(spec_source "")
+    set(spec_out_type "tyir")
+    set(spec_rule "unspecified")
+    set(spec_patterns "")
+
+    file(STRINGS "${spec_path}" spec_lines)
+    foreach(spec_line IN LISTS spec_lines)
+        if(spec_line MATCHES "^# source: (.+)$")
+            set(spec_source "${CMAKE_MATCH_1}")
+        elseif(spec_line MATCHES "^# out-type: (.+)$")
+            set(spec_out_type "${CMAKE_MATCH_1}")
+        elseif(spec_line MATCHES "^# rule: (.+)$")
+            set(spec_rule "${CMAKE_MATCH_1}")
+        elseif(spec_line MATCHES "^#" OR spec_line STREQUAL "")
+            continue()
+        else()
+            list(APPEND spec_patterns "${spec_line}")
+        endif()
+    endforeach()
+
+    if(spec_source STREQUAL "")
+        message(FATAL_ERROR "Pattern spec is missing '# source: ...': ${spec_path}")
+    endif()
+    if(spec_patterns STREQUAL "")
+        message(FATAL_ERROR "Pattern spec has no expected patterns: ${spec_path}")
+    endif()
+
+    set(PATTERN_SPEC_SOURCE "${spec_source}" PARENT_SCOPE)
+    set(PATTERN_SPEC_OUT_TYPE "${spec_out_type}" PARENT_SCOPE)
+    set(PATTERN_SPEC_RULE "${spec_rule}" PARENT_SCOPE)
+    set(PATTERN_SPEC_PATTERNS "${spec_patterns}" PARENT_SCOPE)
+endfunction()
+
+function(resolve_source_path source_path)
+    if(IS_ABSOLUTE "${source_path}")
+        set(resolved_source_path "${source_path}")
+    else()
+        set(resolved_source_path "${CICEST_SOURCE_DIR}/${source_path}")
+    endif()
+
+    if(NOT EXISTS "${resolved_source_path}")
+        message(FATAL_ERROR "Evidence source does not exist: ${resolved_source_path}")
+    endif()
+
+    set(RESOLVED_SOURCE_PATH "${resolved_source_path}" PARENT_SCOPE)
+endfunction()
+
+function(assert_ordered_patterns spec_path actual_output)
+    set(search_offset 0)
+    foreach(pattern IN LISTS ARGN)
+        string(SUBSTRING "${actual_output}" ${search_offset} -1 remaining_output)
+        string(FIND "${remaining_output}" "${pattern}" pattern_index)
+        if(pattern_index EQUAL -1)
+            message(FATAL_ERROR
+                "Expected pattern not found in ${spec_path}\n"
+                "Pattern:\n${pattern}\n")
+        endif()
+
+        string(LENGTH "${pattern}" pattern_length)
+        math(EXPR search_offset "${search_offset} + ${pattern_index} + ${pattern_length}")
+    endforeach()
+endfunction()
+
+file(GLOB tyir_specs "${AVAILABILITY_EVIDENCE_SOURCE_DIR}/tyir/*.patterns")
+file(GLOB diagnostic_specs "${AVAILABILITY_EVIDENCE_SOURCE_DIR}/diagnostics/*.patterns")
+list(SORT tyir_specs)
+list(SORT diagnostic_specs)
+
+set(total_specs 0)
+set(passed_specs 0)
+
+foreach(spec_path IN LISTS tyir_specs)
+    math(EXPR total_specs "${total_specs} + 1")
+    read_pattern_spec("${spec_path}")
+    resolve_source_path("${PATTERN_SPEC_SOURCE}")
+
+    execute_process(
+        COMMAND "${CSTC_INSPECT_BINARY}" "${RESOLVED_SOURCE_PATH}" --out-type "${PATTERN_SPEC_OUT_TYPE}"
+        RESULT_VARIABLE inspect_result
+        OUTPUT_VARIABLE inspect_stdout
+        ERROR_VARIABLE inspect_stderr
+    )
+
+    if(NOT inspect_result EQUAL 0)
+        message(FATAL_ERROR
+            "TyIR evidence failed for ${PATTERN_SPEC_RULE}: ${PATTERN_SPEC_SOURCE}\n"
+            "Exit code: ${inspect_result}\n"
+            "Stderr:\n${inspect_stderr}")
+    endif()
+
+    assert_ordered_patterns("${spec_path}" "${inspect_stdout}" ${PATTERN_SPEC_PATTERNS})
+    math(EXPR passed_specs "${passed_specs} + 1")
+endforeach()
+
+set(diagnostic_output_dir "${AVAILABILITY_EVIDENCE_BINARY_DIR}/diagnostics")
+file(MAKE_DIRECTORY "${diagnostic_output_dir}")
+
+foreach(spec_path IN LISTS diagnostic_specs)
+    math(EXPR total_specs "${total_specs} + 1")
+    read_pattern_spec("${spec_path}")
+    resolve_source_path("${PATTERN_SPEC_SOURCE}")
+
+    get_filename_component(spec_name "${spec_path}" NAME_WE)
+    set(output_stem "${diagnostic_output_dir}/${spec_name}")
+
+    execute_process(
+        COMMAND "${CSTC_BINARY}" "${RESOLVED_SOURCE_PATH}" -o "${output_stem}" --emit exe
+        RESULT_VARIABLE compile_result
+        OUTPUT_VARIABLE compile_stdout
+        ERROR_VARIABLE compile_stderr
+    )
+
+    if(compile_result EQUAL 0)
+        message(FATAL_ERROR
+            "Diagnostic evidence expected compilation to fail for ${PATTERN_SPEC_RULE}: "
+            "${PATTERN_SPEC_SOURCE}")
+    endif()
+
+    assert_ordered_patterns("${spec_path}" "${compile_stderr}" ${PATTERN_SPEC_PATTERNS})
+    math(EXPR passed_specs "${passed_specs} + 1")
+endforeach()
+
+if(total_specs EQUAL 0)
+    message(FATAL_ERROR "Availability evidence suite has no pattern specs")
+endif()
+
+message("Availability evidence summary\n  Specs: ${passed_specs}/${total_specs} passed")

--- a/test/availability_evidence/tyir/availability_validation.patterns
+++ b/test/availability_evidence/tyir/availability_validation.patterns
@@ -1,0 +1,14 @@
+# source: test/e2e/pass/runtime/availability_validation.cst
+# out-type: tyir
+# rule: call_lifting,runtime_block
+Let static_value: num =
+TyLiteral(3): num
+Let dynamic_value: runtime num =
+TyCall(checked_add): runtime num
+TyCall(source): runtime num
+TyLiteral(2): num
+Let bounded: runtime num =
+TyRuntimeBlock: runtime num
+TyCall(checked_add): runtime num
+TyCall(source): runtime num
+TyLiteral(3): num

--- a/test/availability_evidence/tyir/availability_window_config.patterns
+++ b/test/availability_evidence/tyir/availability_window_config.patterns
@@ -1,0 +1,19 @@
+# source: test/e2e/pass/runtime/availability_window_config.cst
+# out-type: tyir
+# rule: aggregate_generic_lifting,ct_required,runtime_block
+TyStructDecl Window<T>
+TyFnDecl checked_limit(value: num, limit: !runtime num) -> num
+TyFnDecl mk_window<T>(primary: T, fallback: T, limit: !runtime num) -> Window<T>
+Let static_window: Window<num> =
+TyStructInit(Window): Window<num>
+TyLiteral(8): num
+Let dynamic_window: runtime Window<num> =
+TyCall(mk_window): runtime Window<num>
+TyCall(checked_limit): runtime num
+TyCall(load_value): runtime num
+Let dynamic_value: runtime num =
+TyCall(choose): runtime num
+Let bounded: runtime num =
+TyRuntimeBlock: runtime num
+TyCall(choose): runtime num
+TyCall(mk_window): runtime Window<num>

--- a/test/availability_evidence/tyir/ct_required_parameters.patterns
+++ b/test/availability_evidence/tyir/ct_required_parameters.patterns
@@ -1,0 +1,11 @@
+# source: test/e2e/pass/runtime/ct_required_parameters.cst
+# out-type: tyir
+# rule: ct_required
+TyFnDecl reserve(count: !runtime num, extra: !runtime num) -> num
+TyFnDecl static_id<T>(value: !runtime T) -> T
+Let reserved: num =
+TyLiteral(22): num
+Let generic_reserved: num =
+TyLiteral(5): num
+Let lifted: runtime num =
+TyCall(add): runtime num

--- a/test/availability_evidence/tyir/runtime_block_partial_normalization.patterns
+++ b/test/availability_evidence/tyir/runtime_block_partial_normalization.patterns
@@ -1,0 +1,7 @@
+# source: test/e2e/pass/runtime/runtime_block_partial_normalization.cst
+# out-type: tyir
+# rule: runtime_block_partial_normalization
+Let value: runtime num =
+TyRuntimeBlock: runtime num
+TyBlock: num
+TyLiteral(3): num

--- a/test/availability_evidence/tyir/runtime_join_promotion.patterns
+++ b/test/availability_evidence/tyir/runtime_join_promotion.patterns
@@ -1,0 +1,14 @@
+# source: test/e2e/pass/runtime/runtime_join_promotion.cst
+# out-type: tyir
+# rule: structural_join
+Let value: runtime num =
+TyIf: runtime num
+Condition
+TyBinary(>): runtime bool
+TyCall(source): runtime num
+Then
+TyBlock: num
+TyLiteral(1): num
+Else
+TyBlock: runtime num
+TyCall(source): runtime num

--- a/test/e2e/pass/runtime/runtime_join_promotion.cst
+++ b/test/e2e/pass/runtime/runtime_join_promotion.cst
@@ -3,6 +3,6 @@ runtime fn source() -> num {
 }
 
 fn main() {
-    let value: runtime num = if true { 1 } else { source() };
+    let value: runtime num = if source() > 0 { 1 } else { source() };
     let _ = value;
 }


### PR DESCRIPTION
Closes #56 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer compiler return-type diagnostics now show expected vs. found types for easier debugging.

* **Tests**
  * Added an availability-evidence test suite and CTest target to broaden end-to-end validation of compiler behaviors and runtime/compile-time distinctions.

* **Documentation**
  * New README and inventory documenting the availability evidence framework, pattern/spec formats, and coverage mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->