### PR TITLE
feat: enforce and document whole-term availability in runtime

### DIFF
--- a/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
+++ b/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
@@ -512,6 +512,8 @@ static void test_never_call_seals_block() {
         std::nullopt,
         cstc::tyir::ty::never(),
         span,
+        true,
+        std::nullopt,
     });
     const auto if_expr = cstc::tyir::make_ty_expr(
         span, cstc::tyir::TyIf{cond, then_block, std::nullopt}, cstc::tyir::ty::unit());
@@ -531,6 +533,8 @@ static void test_never_call_seals_block() {
         tail,
         cstc::tyir::ty::num(),
         span,
+        true,
+        std::nullopt,
     });
     ty_fn.span = span;
     ty_fn.is_runtime = false;

--- a/compiler/cstc_tyir/README.md
+++ b/compiler/cstc_tyir/README.md
@@ -91,8 +91,15 @@ struct TyBlock {
     std::optional<TyExprPtr> tail;
     Ty ty;   // = tail->ty when tail exists; else Unit or Never (by fallthrough)
     SourceSpan span;
+    bool ct_available;
+    std::optional<TyRuntimeEvidence> runtime_evidence;
 };
 ```
+
+`ct_available` is computed from the whole block term, not just the tail value.
+Statement initializers, expression statements, control-flow headers, loop bodies,
+and the tail all contribute. `runtime_evidence` records the first body-internal
+runtime contributor that must be exposed by an explicit runtime result contract.
 
 ### Item declarations
 

--- a/compiler/cstc_tyir/README.md
+++ b/compiler/cstc_tyir/README.md
@@ -96,10 +96,11 @@ struct TyBlock {
 };
 ```
 
-`ct_available` is computed from the whole block term, not just the tail value.
-Statement initializers, expression statements, control-flow headers, loop bodies,
-and the tail all contribute. `runtime_evidence` records the first body-internal
-runtime contributor that must be exposed by an explicit runtime result contract.
+`ct_available` is computed from the whole reachable block term, not just the tail
+value. Reachable statement initializers, expression statements, control-flow
+headers, loop bodies, and the tail all contribute. `runtime_evidence` records the
+first reachable body-internal runtime contributor that must be exposed by an
+explicit runtime result contract.
 
 ### Item declarations
 

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -328,6 +328,14 @@ struct EnumVariantRef {
     cstc::symbol::Symbol variant_name = cstc::symbol::kInvalidSymbol;
 };
 
+/// First source location that introduced body-internal runtime dependence.
+struct TyRuntimeEvidence {
+    /// Source location of the runtime contributor.
+    cstc::span::SourceSpan span;
+    /// Short diagnostic description of the contributor.
+    std::string reason;
+};
+
 /// Single named-field initializer inside a struct construction expression.
 struct TyStructInitField {
     /// Field name.
@@ -518,12 +526,16 @@ struct TyExpr {
     cstc::span::SourceSpan span;
     /// True when this expression is guaranteed not to depend on runtime input.
     bool ct_available = true;
+    /// Body-internal runtime dependence that must be exposed by a result contract.
+    std::optional<TyRuntimeEvidence> runtime_evidence;
 };
 
 /// Constructs a heap-allocated typed expression.
-[[nodiscard]] inline TyExprPtr
-    make_ty_expr(cstc::span::SourceSpan span, TyExpr::Node node, Ty ty, bool ct_available = true) {
-    return std::make_shared<TyExpr>(TyExpr{std::move(node), std::move(ty), span, ct_available});
+[[nodiscard]] inline TyExprPtr make_ty_expr(
+    cstc::span::SourceSpan span, TyExpr::Node node, Ty ty, bool ct_available = true,
+    std::optional<TyRuntimeEvidence> runtime_evidence = std::nullopt) {
+    return std::make_shared<TyExpr>(
+        TyExpr{std::move(node), std::move(ty), span, ct_available, std::move(runtime_evidence)});
 }
 
 // ─── Statements ──────────────────────────────────────────────────────────────
@@ -574,6 +586,8 @@ struct TyBlock {
     cstc::span::SourceSpan span;
     /// True when the block's yielded value is guaranteed compile-time available.
     bool ct_available = true;
+    /// Body-internal runtime dependence joined from reachable statements and tail.
+    std::optional<TyRuntimeEvidence> runtime_evidence;
 };
 
 /// Typed generic constraint attached to a generic declaration.

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -1394,6 +1394,18 @@ struct LoweredExpr {
         stmt);
 }
 
+[[nodiscard]] static bool stmt_value_is_ct_available(const tyir::TyStmt& stmt) {
+    return std::visit(
+        [](const auto& s) {
+            using S = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
+                return expr_value_is_ct_available(s.init);
+            else
+                return expr_value_is_ct_available(s.expr);
+        },
+        stmt);
+}
+
 static void apply_block_runtime_evidence(tyir::TyBlock& block) {
     if (!block.runtime_evidence.has_value())
         return;
@@ -1422,6 +1434,8 @@ struct LoweredPlace {
 [[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
 
 [[nodiscard]] static bool block_can_fallthrough(const tyir::TyBlock& block);
+
+static void recompute_block_summary(tyir::TyBlock& block);
 
 [[nodiscard]] static std::expected<tyir::TyExprPtr, LowerError> resolve_expr_against_type(
     const tyir::TyExprPtr& expr, const tyir::Ty& expected_ty, LowerCtx& ctx);
@@ -1801,17 +1815,7 @@ struct ParamReferenceVisitor {
             (*block)->tail = std::move(*resolved_tail);
             (*block)->ty =
                 block_can_fallthrough(**block) ? (*(*block)->tail)->ty : tyir::ty::never();
-            (*block)->runtime_evidence = std::nullopt;
-            for (const tyir::TyStmt& stmt : (*block)->stmts) {
-                (*block)->runtime_evidence =
-                    first_runtime_evidence((*block)->runtime_evidence, stmt_runtime_evidence(stmt));
-            }
-            (*block)->runtime_evidence = first_runtime_evidence(
-                (*block)->runtime_evidence, (*(*block)->tail)->runtime_evidence);
-            (*block)->ct_available = value_is_ct_available(
-                block_can_fallthrough(**block) ? expr_value_is_ct_available(*(*block)->tail) : true,
-                (*block)->ty);
-            apply_block_runtime_evidence(**block);
+            recompute_block_summary(**block);
             expr->ty = (*block)->ty;
             expr->ct_available = (*block)->ct_available;
             expr->runtime_evidence = (*block)->runtime_evidence;
@@ -1832,20 +1836,7 @@ struct ParamReferenceVisitor {
             runtime_block->body->ty = block_can_fallthrough(*runtime_block->body)
                                         ? (*runtime_block->body->tail)->ty
                                         : tyir::ty::never();
-            runtime_block->body->runtime_evidence = std::nullopt;
-            for (const tyir::TyStmt& stmt : runtime_block->body->stmts) {
-                runtime_block->body->runtime_evidence = first_runtime_evidence(
-                    runtime_block->body->runtime_evidence, stmt_runtime_evidence(stmt));
-            }
-            runtime_block->body->runtime_evidence = first_runtime_evidence(
-                runtime_block->body->runtime_evidence,
-                (*runtime_block->body->tail)->runtime_evidence);
-            runtime_block->body->ct_available = value_is_ct_available(
-                block_can_fallthrough(*runtime_block->body)
-                    ? expr_value_is_ct_available(*runtime_block->body->tail)
-                    : true,
-                runtime_block->body->ty);
-            apply_block_runtime_evidence(*runtime_block->body);
+            recompute_block_summary(*runtime_block->body);
             expr->ty = runtime_block->body->ty;
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
@@ -1865,20 +1856,7 @@ struct ParamReferenceVisitor {
             if_expr->then_block->ty = block_can_fallthrough(*if_expr->then_block)
                                         ? (*if_expr->then_block->tail)->ty
                                         : tyir::ty::never();
-            if_expr->then_block->runtime_evidence = std::nullopt;
-            for (const tyir::TyStmt& stmt : if_expr->then_block->stmts) {
-                if_expr->then_block->runtime_evidence = first_runtime_evidence(
-                    if_expr->then_block->runtime_evidence, stmt_runtime_evidence(stmt));
-            }
-            if_expr->then_block->runtime_evidence = first_runtime_evidence(
-                if_expr->then_block->runtime_evidence,
-                (*if_expr->then_block->tail)->runtime_evidence);
-            if_expr->then_block->ct_available = value_is_ct_available(
-                block_can_fallthrough(*if_expr->then_block)
-                    ? expr_value_is_ct_available(*if_expr->then_block->tail)
-                    : true,
-                if_expr->then_block->ty);
-            apply_block_runtime_evidence(*if_expr->then_block);
+            recompute_block_summary(*if_expr->then_block);
         }
 
         if (if_expr->else_branch.has_value() && expr_can_fallthrough(*(*if_expr->else_branch))) {
@@ -2463,6 +2441,31 @@ struct ParamReferenceVisitor {
     return expr_can_fallthrough(**block.tail);
 }
 
+static void recompute_block_summary(tyir::TyBlock& block) {
+    bool reachable = true;
+    bool ct_available = true;
+    block.runtime_evidence = std::nullopt;
+
+    for (const tyir::TyStmt& stmt : block.stmts) {
+        if (!reachable)
+            break;
+
+        ct_available = ct_available && stmt_value_is_ct_available(stmt);
+        block.runtime_evidence =
+            first_runtime_evidence(block.runtime_evidence, stmt_runtime_evidence(stmt));
+        reachable = stmt_can_fallthrough(stmt);
+    }
+
+    if (reachable && block.tail.has_value()) {
+        ct_available = ct_available && expr_value_is_ct_available(*block.tail);
+        block.runtime_evidence =
+            first_runtime_evidence(block.runtime_evidence, (*block.tail)->runtime_evidence);
+    }
+
+    block.ct_available = value_is_ct_available(ct_available, block.ty);
+    apply_block_runtime_evidence(block);
+}
+
 // ─── Block lowering ──────────────────────────────────────────────────────────
 
 [[nodiscard]] static std::expected<tyir::TyBlock, LowerError>
@@ -2478,8 +2481,6 @@ struct ParamReferenceVisitor {
             ctx.scope.pop();
             return std::unexpected(std::move(lowered.error()));
         }
-        result.runtime_evidence =
-            first_runtime_evidence(result.runtime_evidence, stmt_runtime_evidence(*lowered));
         result.stmts.push_back(std::move(*lowered));
     }
 
@@ -2497,17 +2498,12 @@ struct ParamReferenceVisitor {
             return make_error(block.span, "block expressions cannot yield references yet");
         }
         release_temp_borrows(ctx, tail->temp_borrows);
-        result.runtime_evidence =
-            first_runtime_evidence(result.runtime_evidence, tail->expr->runtime_evidence);
         result.tail = std::move(tail->expr);
         result.ty = reaches_tail ? (*result.tail)->ty : tyir::ty::never();
-        result.ct_available = reaches_tail ? expr_value_is_ct_available(*result.tail) : true;
     } else {
         result.ty = reaches_tail ? tyir::ty::unit() : tyir::ty::never();
-        result.ct_available = true;
     }
-    result.ct_available = value_is_ct_available(result.ct_available, result.ty);
-    apply_block_runtime_evidence(result);
+    recompute_block_summary(result);
 
     ctx.scope.pop();
     return result;
@@ -3843,16 +3839,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
             return std::unexpected(std::move(resolved_tail.error()));
         body->tail = std::move(*resolved_tail);
         body->ty = block_can_fallthrough(*body) ? (*body->tail)->ty : tyir::ty::never();
-        body->runtime_evidence = std::nullopt;
-        for (const tyir::TyStmt& stmt : body->stmts) {
-            body->runtime_evidence =
-                first_runtime_evidence(body->runtime_evidence, stmt_runtime_evidence(stmt));
-        }
-        body->runtime_evidence =
-            first_runtime_evidence(body->runtime_evidence, (*body->tail)->runtime_evidence);
-        body->ct_available =
-            value_is_ct_available(expr_value_is_ct_available(*body->tail), body->ty);
-        apply_block_runtime_evidence(*body);
+        recompute_block_summary(*body);
     }
 
     const bool implicit_unit_result = !sig.has_explicit_return_type && sig.return_ty.is_unit();

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -1951,14 +1951,14 @@ struct ParamReferenceVisitor {
         generic_args.push_back(found->second);
     }
 
-    const tyir::Ty resolved_return_ty = call_result_type(
-        annotate_type_semantics(apply_substitution(sig.return_ty, substitution), ctx.env),
-        deferred->args);
+    const tyir::Ty resolved_return_shape =
+        annotate_type_semantics(apply_substitution(sig.return_ty, substitution), ctx.env);
+    const tyir::Ty resolved_return_ty = call_result_type(resolved_return_shape, deferred->args);
     const bool deferred_call_ct_available =
         value_is_ct_available(all_exprs_ct_available(deferred->args), resolved_return_ty);
     const auto deferred_runtime_evidence = first_runtime_evidence(
         first_runtime_evidence(deferred->args),
-        type_has_runtime_dependency(sig.return_ty)
+        type_has_runtime_dependency(resolved_return_shape)
             ? runtime_evidence_at(expr->span, "runtime-result call")
             : std::nullopt);
     if (!fully_resolved) {
@@ -2002,7 +2002,7 @@ struct ParamReferenceVisitor {
         value_is_ct_available(all_exprs_ct_available(resolved_args), lifted_return_ty);
     const auto call_runtime_evidence = first_runtime_evidence(
         first_runtime_evidence(resolved_args),
-        type_has_runtime_dependency(resolved_return_ty)
+        type_has_runtime_dependency(resolved_return_shape)
             ? runtime_evidence_at(expr->span, "runtime-result call")
             : std::nullopt);
 
@@ -3205,10 +3205,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     resolved_generic_args.push_back(found->second);
                 }
 
-                const tyir::Ty resolved_return_ty = call_result_type(
-                    annotate_type_semantics(
-                        apply_substitution(sig.return_ty, substitution), ctx.env),
-                    lowered_args);
+                const tyir::Ty resolved_return_shape = annotate_type_semantics(
+                    apply_substitution(sig.return_ty, substitution), ctx.env);
+                const tyir::Ty resolved_return_ty =
+                    call_result_type(resolved_return_shape, lowered_args);
 
                 tyir::TyExprPtr lowered_expr;
                 if (fully_resolved) {
@@ -3247,7 +3247,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     const bool call_ct_available = all_exprs_ct_available(lowered_args);
                     const auto call_runtime_evidence = first_runtime_evidence(
                         args_runtime_evidence,
-                        type_has_runtime_dependency(resolved_return_ty)
+                        type_has_runtime_dependency(resolved_return_shape)
                             ? runtime_evidence_at(expr->span, "runtime-result call")
                             : std::nullopt);
 
@@ -3262,7 +3262,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     const bool call_ct_available = all_exprs_ct_available(lowered_args);
                     const auto call_runtime_evidence = first_runtime_evidence(
                         args_runtime_evidence,
-                        type_has_runtime_dependency(resolved_return_ty)
+                        type_has_runtime_dependency(resolved_return_shape)
                             ? runtime_evidence_at(expr->span, "runtime-result call")
                             : std::nullopt);
                     lowered_expr = tyir::make_ty_expr(

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -34,6 +34,7 @@ struct FnSignature {
     tyir::Ty return_ty;
     cstc::span::SourceSpan span;
     std::vector<cstc::ast::GenericParam> generic_params;
+    bool has_explicit_return_type = false;
 };
 
 /// Global type and function environment built during the collection passes.
@@ -486,6 +487,7 @@ public:
         std::size_t active_borrows = 0;
         std::optional<std::size_t> borrowed_local;
         bool ct_available = true;
+        std::optional<tyir::TyRuntimeEvidence> runtime_evidence;
     };
 
     void push() { frames_.push_back(Frame{{}, locals_.size()}); }
@@ -505,7 +507,8 @@ public:
 
     [[nodiscard]] bool insert(
         cstc::symbol::Symbol name, tyir::Ty ty,
-        std::optional<std::size_t> borrowed_local = std::nullopt, bool ct_available = true) {
+        std::optional<std::size_t> borrowed_local = std::nullopt, bool ct_available = true,
+        std::optional<tyir::TyRuntimeEvidence> runtime_evidence = std::nullopt) {
         assert(!frames_.empty());
         if (frames_.back().bindings.contains(name))
             return false;
@@ -515,7 +518,10 @@ public:
 
         const std::size_t index = locals_.size();
         const bool stored_ct_available = value_is_ct_available(ct_available, ty);
-        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local, stored_ct_available});
+        locals_.push_back(
+            LocalState{
+                std::move(ty), false, 0, borrowed_local, stored_ct_available,
+                std::move(runtime_evidence)});
         frames_.back().bindings.emplace(name, index);
         return true;
     }
@@ -1353,6 +1359,49 @@ struct LoweredExpr {
     bool deferred_generic_probe_validation = false;
 };
 
+[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
+    runtime_evidence_at(cstc::span::SourceSpan span, std::string reason) {
+    return tyir::TyRuntimeEvidence{span, std::move(reason)};
+}
+
+[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence> first_runtime_evidence(
+    const std::optional<tyir::TyRuntimeEvidence>& lhs,
+    const std::optional<tyir::TyRuntimeEvidence>& rhs) {
+    if (lhs.has_value())
+        return lhs;
+    return rhs;
+}
+
+[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
+    first_runtime_evidence(const std::vector<tyir::TyExprPtr>& exprs) {
+    for (const tyir::TyExprPtr& expr : exprs) {
+        if (expr != nullptr && expr->runtime_evidence.has_value())
+            return expr->runtime_evidence;
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
+    stmt_runtime_evidence(const tyir::TyStmt& stmt) {
+    return std::visit(
+        [](const auto& s) -> std::optional<tyir::TyRuntimeEvidence> {
+            using S = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
+                return s.init != nullptr ? s.init->runtime_evidence : std::nullopt;
+            else
+                return s.expr != nullptr ? s.expr->runtime_evidence : std::nullopt;
+        },
+        stmt);
+}
+
+static void apply_block_runtime_evidence(tyir::TyBlock& block) {
+    if (!block.runtime_evidence.has_value())
+        return;
+    block.ct_available = false;
+    if (!block.ty.is_never())
+        block.ty.is_runtime = true;
+}
+
 struct LoweredPlace {
     tyir::TyExprPtr expr;
     std::optional<std::size_t> owner_local;
@@ -1386,6 +1435,7 @@ struct LoweredPlace {
     FnSignature sig;
     sig.span = span;
     sig.generic_params = generic_params;
+    sig.has_explicit_return_type = return_type.has_value();
     const GenericParamSet generic_param_set = make_generic_param_set(generic_params);
     if (return_type.has_value()) {
         auto t = lower_type(*return_type, env, span, generic_param_set);
@@ -1751,11 +1801,20 @@ struct ParamReferenceVisitor {
             (*block)->tail = std::move(*resolved_tail);
             (*block)->ty =
                 block_can_fallthrough(**block) ? (*(*block)->tail)->ty : tyir::ty::never();
+            (*block)->runtime_evidence = std::nullopt;
+            for (const tyir::TyStmt& stmt : (*block)->stmts) {
+                (*block)->runtime_evidence =
+                    first_runtime_evidence((*block)->runtime_evidence, stmt_runtime_evidence(stmt));
+            }
+            (*block)->runtime_evidence = first_runtime_evidence(
+                (*block)->runtime_evidence, (*(*block)->tail)->runtime_evidence);
             (*block)->ct_available = value_is_ct_available(
                 block_can_fallthrough(**block) ? expr_value_is_ct_available(*(*block)->tail) : true,
                 (*block)->ty);
+            apply_block_runtime_evidence(**block);
             expr->ty = (*block)->ty;
             expr->ct_available = (*block)->ct_available;
+            expr->runtime_evidence = (*block)->runtime_evidence;
         }
         return expr;
     }
@@ -1773,16 +1832,26 @@ struct ParamReferenceVisitor {
             runtime_block->body->ty = block_can_fallthrough(*runtime_block->body)
                                         ? (*runtime_block->body->tail)->ty
                                         : tyir::ty::never();
+            runtime_block->body->runtime_evidence = std::nullopt;
+            for (const tyir::TyStmt& stmt : runtime_block->body->stmts) {
+                runtime_block->body->runtime_evidence = first_runtime_evidence(
+                    runtime_block->body->runtime_evidence, stmt_runtime_evidence(stmt));
+            }
+            runtime_block->body->runtime_evidence = first_runtime_evidence(
+                runtime_block->body->runtime_evidence,
+                (*runtime_block->body->tail)->runtime_evidence);
             runtime_block->body->ct_available = value_is_ct_available(
                 block_can_fallthrough(*runtime_block->body)
                     ? expr_value_is_ct_available(*runtime_block->body->tail)
                     : true,
                 runtime_block->body->ty);
+            apply_block_runtime_evidence(*runtime_block->body);
             expr->ty = runtime_block->body->ty;
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
         expr->ct_available = false;
+        expr->runtime_evidence = runtime_evidence_at(expr->span, "runtime block");
         return expr;
     }
 
@@ -1796,11 +1865,20 @@ struct ParamReferenceVisitor {
             if_expr->then_block->ty = block_can_fallthrough(*if_expr->then_block)
                                         ? (*if_expr->then_block->tail)->ty
                                         : tyir::ty::never();
+            if_expr->then_block->runtime_evidence = std::nullopt;
+            for (const tyir::TyStmt& stmt : if_expr->then_block->stmts) {
+                if_expr->then_block->runtime_evidence = first_runtime_evidence(
+                    if_expr->then_block->runtime_evidence, stmt_runtime_evidence(stmt));
+            }
+            if_expr->then_block->runtime_evidence = first_runtime_evidence(
+                if_expr->then_block->runtime_evidence,
+                (*if_expr->then_block->tail)->runtime_evidence);
             if_expr->then_block->ct_available = value_is_ct_available(
                 block_can_fallthrough(*if_expr->then_block)
                     ? expr_value_is_ct_available(*if_expr->then_block->tail)
                     : true,
                 if_expr->then_block->ty);
+            apply_block_runtime_evidence(*if_expr->then_block);
         }
 
         if (if_expr->else_branch.has_value() && expr_can_fallthrough(*(*if_expr->else_branch))) {
@@ -1822,10 +1900,20 @@ struct ParamReferenceVisitor {
         const bool else_ct_available = if_expr->else_branch.has_value()
                                          ? expr_value_is_ct_available(*if_expr->else_branch)
                                          : true;
+        expr->runtime_evidence = first_runtime_evidence(
+            first_runtime_evidence(
+                if_expr->condition->runtime_evidence, if_expr->then_block->runtime_evidence),
+            if_expr->else_branch.has_value() ? (*if_expr->else_branch)->runtime_evidence
+                                             : std::nullopt);
         expr->ct_available = value_is_ct_available(
             expr_value_is_ct_available(if_expr->condition) && if_expr->then_block->ct_available
                 && else_ct_available,
             expr->ty);
+        if (expr->runtime_evidence.has_value()) {
+            expr->ct_available = false;
+            if (!expr->ty.is_never())
+                expr->ty.is_runtime = true;
+        }
         return expr;
     }
 
@@ -1871,11 +1959,16 @@ struct ParamReferenceVisitor {
         deferred->args);
     const bool deferred_call_ct_available =
         value_is_ct_available(all_exprs_ct_available(deferred->args), resolved_return_ty);
+    const auto deferred_runtime_evidence = first_runtime_evidence(
+        first_runtime_evidence(deferred->args),
+        type_has_runtime_dependency(sig.return_ty)
+            ? runtime_evidence_at(expr->span, "runtime-result call")
+            : std::nullopt);
     if (!fully_resolved) {
         return tyir::make_ty_expr(
             expr->span,
             tyir::TyDeferredGenericCall{deferred->fn_name, std::move(generic_args), deferred->args},
-            resolved_return_ty, deferred_call_ct_available);
+            resolved_return_ty, deferred_call_ct_available, deferred_runtime_evidence);
     }
 
     std::vector<tyir::Ty> concrete_generic_args;
@@ -1910,11 +2003,16 @@ struct ParamReferenceVisitor {
     const tyir::Ty lifted_return_ty = lift_call_result_type(resolved_return_ty, resolved_args);
     const bool call_ct_available =
         value_is_ct_available(all_exprs_ct_available(resolved_args), lifted_return_ty);
+    const auto call_runtime_evidence = first_runtime_evidence(
+        first_runtime_evidence(resolved_args),
+        type_has_runtime_dependency(resolved_return_ty)
+            ? runtime_evidence_at(expr->span, "runtime-result call")
+            : std::nullopt);
 
     return tyir::make_ty_expr(
         expr->span,
         tyir::TyCall{deferred->fn_name, std::move(concrete_generic_args), std::move(resolved_args)},
-        lifted_return_ty, call_ct_available);
+        lifted_return_ty, call_ct_available, call_runtime_evidence);
 }
 
 [[nodiscard]] static std::expected<cstc::symbol::Symbol, LowerError>
@@ -2252,7 +2350,9 @@ struct ParamReferenceVisitor {
                         "borrow instead");
                 }
                 if (!s.discard && s.name.is_valid()
-                    && !ctx.scope.insert(s.name, binding_ty, borrowed_local, binding_ct_available))
+                    && !ctx.scope.insert(
+                        s.name, binding_ty, borrowed_local, binding_ct_available,
+                        init->expr->runtime_evidence))
                     return make_error(
                         s.span, "duplicate local binding '" + std::string(s.name.as_str()) + "'");
 
@@ -2378,6 +2478,8 @@ struct ParamReferenceVisitor {
             ctx.scope.pop();
             return std::unexpected(std::move(lowered.error()));
         }
+        result.runtime_evidence =
+            first_runtime_evidence(result.runtime_evidence, stmt_runtime_evidence(*lowered));
         result.stmts.push_back(std::move(*lowered));
     }
 
@@ -2395,6 +2497,8 @@ struct ParamReferenceVisitor {
             return make_error(block.span, "block expressions cannot yield references yet");
         }
         release_temp_borrows(ctx, tail->temp_borrows);
+        result.runtime_evidence =
+            first_runtime_evidence(result.runtime_evidence, tail->expr->runtime_evidence);
         result.tail = std::move(tail->expr);
         result.ty = reaches_tail ? (*result.tail)->ty : tyir::ty::never();
         result.ct_available = reaches_tail ? expr_value_is_ct_available(*result.tail) : true;
@@ -2403,6 +2507,7 @@ struct ParamReferenceVisitor {
         result.ct_available = true;
     }
     result.ct_available = value_is_ct_available(result.ct_available, result.ty);
+    apply_block_runtime_evidence(result);
 
     ctx.scope.pop();
     return result;
@@ -2482,7 +2587,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 return LoweredPlace{
                     tyir::make_ty_expr(
                         expr->span, tyir::LocalRef{node.head, tyir::ValueUseKind::Borrow}, local.ty,
-                        local.ct_available),
+                        local.ct_available, local.runtime_evidence),
                     local_index,
                 };
             } else if constexpr (std::is_same_v<N, ast::FieldAccessExpr>) {
@@ -2515,13 +2620,14 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 tyir::Ty lowered_field_ty =
                     propagate_runtime_tag(*field_ty, base->expr->ty.is_runtime);
                 const bool field_ct_available = expr_value_is_ct_available(base->expr);
+                const auto field_runtime_evidence = base->expr->runtime_evidence;
 
                 return LoweredPlace{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{
                             std::move(base->expr), node.field, tyir::ValueUseKind::Borrow},
-                        lowered_field_ty, field_ct_available),
+                        lowered_field_ty, field_ct_available, field_runtime_evidence),
                     base->owner_local,
                 };
             } else {
@@ -2621,7 +2727,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     return LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::LocalRef{node.head, use_kind}, local.ty,
-                            local.ct_available),
+                            local.ct_available, local.runtime_evidence),
                         {},
                         local.ty.is_ref() ? local.borrowed_local : std::nullopt,
                     };
@@ -2683,6 +2789,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     seen_fields;
                 seen_fields.reserve(node.fields.size());
                 bool fields_ct_available = true;
+                std::optional<tyir::TyRuntimeEvidence> fields_runtime_evidence;
 
                 for (const ast::StructInitField& field : node.fields) {
                     auto expected_ty = ctx.env.field_ty(type_name, field.name);
@@ -2718,6 +2825,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     append_temp_borrows(temp_borrows, std::move(val->temp_borrows));
                     fields_ct_available =
                         fields_ct_available && expr_value_is_ct_available(val->expr);
+                    fields_runtime_evidence = first_runtime_evidence(
+                        fields_runtime_evidence, val->expr->runtime_evidence);
 
                     lowered_fields.push_back(
                         tyir::TyStructInitField{field.name, std::move(val->expr), field.span});
@@ -2742,7 +2851,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         tyir::TyStructInit{
                             type_name, std::move(lowered_generic_args), std::move(lowered_fields)},
-                        result_ty, fields_ct_available),
+                        result_ty, fields_ct_available, fields_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -2767,11 +2876,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         }
                         const tyir::Ty ref_ty = tyir::ty::ref(place->expr->ty);
                         const bool borrow_ct_available = expr_value_is_ct_available(place->expr);
+                        const auto borrow_runtime_evidence = place->expr->runtime_evidence;
 
                         return LoweredExpr{
                             tyir::make_ty_expr(
                                 expr->span, tyir::TyBorrow{std::move(place->expr)}, ref_ty,
-                                borrow_ct_available),
+                                borrow_ct_available, borrow_runtime_evidence),
                             std::move(temp_borrows),
                             place->owner_local,
                         };
@@ -2783,21 +2893,23 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                     if (rhs->expr->ty.is_never()) {
                         const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
+                        const auto borrow_runtime_evidence = rhs->expr->runtime_evidence;
                         return LoweredExpr{
                             tyir::make_ty_expr(
                                 expr->span, tyir::TyBorrow{std::move(rhs->expr)}, tyir::ty::never(),
-                                borrow_ct_available),
+                                borrow_ct_available, borrow_runtime_evidence),
                             std::move(rhs->temp_borrows),
                             std::nullopt,
                         };
                     }
                     const tyir::Ty ref_ty = tyir::ty::ref(rhs->expr->ty);
                     const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
+                    const auto borrow_runtime_evidence = rhs->expr->runtime_evidence;
 
                     return LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::TyBorrow{std::move(rhs->expr)}, ref_ty,
-                            borrow_ct_available),
+                            borrow_ct_available, borrow_runtime_evidence),
                         std::move(rhs->temp_borrows),
                         std::nullopt,
                     };
@@ -2828,10 +2940,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     }
 
                     const bool unary_ct_available = expr_value_is_ct_available(rhs->expr);
+                    const auto unary_runtime_evidence = rhs->expr->runtime_evidence;
                     auto lowered = LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::TyUnary{node.op, std::move(rhs->expr)}, result_ty,
-                            unary_ct_available),
+                            unary_ct_available, unary_runtime_evidence),
                         {},
                         std::nullopt,
                     };
@@ -2921,11 +3034,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 const bool binary_ct_available =
                     expr_value_is_ct_available(lhs->expr) && expr_value_is_ct_available(rhs->expr);
+                const auto binary_runtime_evidence = first_runtime_evidence(
+                    lhs->expr->runtime_evidence, rhs->expr->runtime_evidence);
                 auto lowered = LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyBinary{node.op, std::move(lhs->expr), std::move(rhs->expr)},
-                        std::move(result_ty), binary_ct_available),
+                        std::move(result_ty), binary_ct_available, binary_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -2954,7 +3069,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{access->base, access->field, tyir::ValueUseKind::Copy},
-                        place->expr->ty, field_ct_available),
+                        place->expr->ty, field_ct_available, place->expr->runtime_evidence),
                     {},
                     place->expr->ty.is_ref() ? place->owner_local : std::nullopt,
                 };
@@ -3012,12 +3127,15 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 std::vector<tyir::TyExprPtr> lowered_args;
                 lowered_args.reserve(node.args.size());
                 std::vector<std::size_t> temp_borrows;
+                std::optional<tyir::TyRuntimeEvidence> args_runtime_evidence;
 
                 for (const ast::ExprPtr& arg_expr : node.args) {
                     auto arg = lower_expr(arg_expr, ctx);
                     if (!arg)
                         return std::unexpected(std::move(arg.error()));
                     append_temp_borrows(temp_borrows, std::move(arg->temp_borrows));
+                    args_runtime_evidence =
+                        first_runtime_evidence(args_runtime_evidence, arg->expr->runtime_evidence);
                     lowered_args.push_back(std::move(arg->expr));
                 }
 
@@ -3112,21 +3230,31 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
                     const bool call_ct_available = all_exprs_ct_available(lowered_args);
+                    const auto call_runtime_evidence = first_runtime_evidence(
+                        args_runtime_evidence,
+                        type_has_runtime_dependency(resolved_return_ty)
+                            ? runtime_evidence_at(expr->span, "runtime-result call")
+                            : std::nullopt);
 
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyCall{
                             fn_name, std::move(concrete_generic_args), std::move(lowered_args)},
-                        lifted_return_ty, call_ct_available);
+                        lifted_return_ty, call_ct_available, call_runtime_evidence);
                 } else {
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
                     const bool call_ct_available = all_exprs_ct_available(lowered_args);
+                    const auto call_runtime_evidence = first_runtime_evidence(
+                        args_runtime_evidence,
+                        type_has_runtime_dependency(resolved_return_ty)
+                            ? runtime_evidence_at(expr->span, "runtime-result call")
+                            : std::nullopt);
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyDeferredGenericCall{
                             fn_name, std::move(resolved_generic_args), std::move(lowered_args)},
-                        lifted_return_ty, call_ct_available);
+                        lifted_return_ty, call_ct_available, call_runtime_evidence);
                 }
 
                 auto lowered = LoweredExpr{
@@ -3157,7 +3285,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty, false),
+                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty, false,
+                        runtime_evidence_at(expr->span, "runtime block")),
                     {},
                     std::nullopt,
                 };
@@ -3171,9 +3300,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 tyir::Ty block_ty = block->ty;
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
                 const bool block_ct_available = block_ptr->ct_available;
+                const auto block_runtime_evidence = block_ptr->runtime_evidence;
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, std::move(block_ptr), block_ty, block_ct_available),
+                        expr->span, std::move(block_ptr), block_ty, block_ct_available,
+                        block_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3202,6 +3333,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 tyir::Ty result_ty = then_ptr->ty;
                 const bool condition_ct_available = expr_value_is_ct_available(cond->expr);
                 bool if_ct_available = condition_ct_available && then_ptr->ct_available;
+                std::optional<tyir::TyRuntimeEvidence> if_runtime_evidence = first_runtime_evidence(
+                    cond->expr->runtime_evidence, then_ptr->runtime_evidence);
 
                 std::optional<tyir::TyExprPtr> else_branch;
                 if (node.else_branch.has_value()) {
@@ -3236,6 +3369,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         ctx.scope.merge_from(else_ctx.scope);
 
                     if_ct_available = if_ct_available && expr_value_is_ct_available(else_val->expr);
+                    if_runtime_evidence = first_runtime_evidence(
+                        if_runtime_evidence, else_val->expr->runtime_evidence);
                     else_branch = std::move(else_val->expr);
                 } else {
                     // No else branch: result type is Unit
@@ -3251,13 +3386,18 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 if (result_ty.is_ref())
                     return make_error(expr->span, "'if' expressions cannot yield references yet");
+                if (if_runtime_evidence.has_value()) {
+                    if_ct_available = false;
+                    if (!result_ty.is_never())
+                        result_ty.is_runtime = true;
+                }
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyIf{
                             std::move(cond->expr), std::move(then_ptr), std::move(else_branch)},
-                        result_ty, if_ct_available),
+                        result_ty, if_ct_available, if_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3283,9 +3423,19 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
+                std::optional<tyir::TyRuntimeEvidence> loop_runtime_evidence =
+                    body_ptr->runtime_evidence;
+                tyir::Ty lowered_loop_ty = loop_ty;
+                bool lowered_loop_ct_available = loop_ct_available;
+                if (loop_runtime_evidence.has_value()) {
+                    lowered_loop_ct_available = false;
+                    if (!lowered_loop_ty.is_never())
+                        lowered_loop_ty.is_runtime = true;
+                }
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyLoop{std::move(body_ptr)}, loop_ty, loop_ct_available),
+                        expr->span, tyir::TyLoop{std::move(body_ptr)}, lowered_loop_ty,
+                        lowered_loop_ct_available, loop_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3315,12 +3465,20 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                const bool while_ct_available = condition_ct_available && body_ptr->ct_available;
+                std::optional<tyir::TyRuntimeEvidence> while_runtime_evidence =
+                    first_runtime_evidence(
+                        cond->expr->runtime_evidence, body_ptr->runtime_evidence);
+                bool while_ct_available = condition_ct_available && body_ptr->ct_available;
+                tyir::Ty while_ty = tyir::ty::unit();
+                if (while_runtime_evidence.has_value()) {
+                    while_ct_available = false;
+                    while_ty.is_runtime = true;
+                }
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span, tyir::TyWhile{std::move(cond->expr), std::move(body_ptr)},
-                        tyir::ty::unit(), while_ct_available),
+                        while_ty, while_ct_available, while_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3333,6 +3491,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 std::optional<tyir::TyForInit> lowered_init;
                 bool for_ct_available = true;
+                std::optional<tyir::TyRuntimeEvidence> for_runtime_evidence;
 
                 if (node.init.has_value()) {
                     const auto& init_var = *node.init;
@@ -3399,7 +3558,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         }
                         if (!init_let->discard && init_let->name.is_valid()
                             && !ctx.scope.insert(
-                                init_let->name, init_ty, borrowed_local, init_ct_available)) {
+                                init_let->name, init_ty, borrowed_local, init_ct_available,
+                                init_expr->expr->runtime_evidence)) {
                             ctx.scope.pop();
                             return make_error(
                                 init_let->span, "duplicate local binding '"
@@ -3407,6 +3567,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
                         for_ct_available = for_ct_available && init_ct_available;
+                        for_runtime_evidence = first_runtime_evidence(
+                            for_runtime_evidence, init_expr->expr->runtime_evidence);
                         lowered_init = tyir::TyForInit{
                             init_let->discard, init_let->name, init_ty, std::move(init_expr->expr),
                             init_let->span};
@@ -3421,6 +3583,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         release_temp_borrows(ctx, init_expr->temp_borrows);
                         for_ct_available =
                             for_ct_available && expr_value_is_ct_available(init_expr->expr);
+                        for_runtime_evidence = first_runtime_evidence(
+                            for_runtime_evidence, init_expr->expr->runtime_evidence);
                         // Treat as a discard init — wrap in TyForInit with discard=true
                         lowered_init = tyir::TyForInit{
                             true, cstc::symbol::kInvalidSymbol, init_expr->expr->ty,
@@ -3446,6 +3610,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     }
                     release_temp_borrows(ctx, cond->temp_borrows);
                     for_ct_available = for_ct_available && expr_value_is_ct_available(cond->expr);
+                    for_runtime_evidence =
+                        first_runtime_evidence(for_runtime_evidence, cond->expr->runtime_evidence);
                     lowered_cond = std::move(cond->expr);
                 }
 
@@ -3461,6 +3627,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 loop_ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
                 for_ct_available = for_ct_available && body_ptr->ct_available;
+                for_runtime_evidence =
+                    first_runtime_evidence(for_runtime_evidence, body_ptr->runtime_evidence);
 
                 std::optional<tyir::TyExprPtr> lowered_step;
                 if (node.step.has_value()) {
@@ -3471,10 +3639,18 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     }
                     release_temp_borrows(loop_ctx, step->temp_borrows);
                     for_ct_available = for_ct_available && expr_value_is_ct_available(step->expr);
+                    for_runtime_evidence =
+                        first_runtime_evidence(for_runtime_evidence, step->expr->runtime_evidence);
                     lowered_step = std::move(step->expr);
                 }
 
                 ctx.scope.pop();
+
+                tyir::Ty for_ty = tyir::ty::unit();
+                if (for_runtime_evidence.has_value()) {
+                    for_ct_available = false;
+                    for_ty.is_runtime = true;
+                }
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
@@ -3482,7 +3658,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         tyir::TyFor{
                             std::move(lowered_init), std::move(lowered_cond),
                             std::move(lowered_step), std::move(body_ptr)},
-                        tyir::ty::unit(), for_ct_available),
+                        for_ty, for_ct_available, for_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3530,9 +3706,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     }
 
                     release_temp_borrows(ctx, val->temp_borrows);
+                    const auto break_runtime_evidence = val->expr->runtime_evidence;
                     return LoweredExpr{
                         tyir::make_ty_expr(
-                            expr->span, tyir::TyBreak{std::move(val->expr)}, tyir::ty::never()),
+                            expr->span, tyir::TyBreak{std::move(val->expr)}, tyir::ty::never(),
+                            true, break_runtime_evidence),
                         {},
                         std::nullopt,
                     };
@@ -3604,9 +3782,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             expr->span, "bare 'return' in function returning '"
                                             + ctx.current_return_ty.display() + "'");
                 }
+                const auto return_runtime_evidence =
+                    lowered_val.has_value() ? (*lowered_val)->runtime_evidence : std::nullopt;
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyReturn{std::move(lowered_val)}, tyir::ty::never()),
+                        expr->span, tyir::TyReturn{std::move(lowered_val)}, tyir::ty::never(), true,
+                        return_runtime_evidence),
                     {},
                     std::nullopt,
                 };
@@ -3619,6 +3800,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
     if (lowered.has_value()) {
         lowered->expr->ct_available =
             value_is_ct_available(lowered->expr->ct_available, lowered->expr->ty);
+        if (lowered->expr->runtime_evidence.has_value())
+            lowered->expr->ct_available = false;
         lowered->deferred_generic_probe_validation = ctx.defer_generic_probe_validation;
     }
     return lowered;
@@ -3660,12 +3843,30 @@ static std::expected<void, LowerError> merge_loop_break_types(
             return std::unexpected(std::move(resolved_tail.error()));
         body->tail = std::move(*resolved_tail);
         body->ty = block_can_fallthrough(*body) ? (*body->tail)->ty : tyir::ty::never();
+        body->runtime_evidence = std::nullopt;
+        for (const tyir::TyStmt& stmt : body->stmts) {
+            body->runtime_evidence =
+                first_runtime_evidence(body->runtime_evidence, stmt_runtime_evidence(stmt));
+        }
+        body->runtime_evidence =
+            first_runtime_evidence(body->runtime_evidence, (*body->tail)->runtime_evidence);
         body->ct_available =
             value_is_ct_available(expr_value_is_ct_available(*body->tail), body->ty);
+        apply_block_runtime_evidence(*body);
+    }
+
+    const bool implicit_unit_result = !sig.has_explicit_return_type && sig.return_ty.is_unit();
+    if (body->runtime_evidence.has_value() && !sig.return_ty.is_runtime && !fn.is_runtime
+        && !implicit_unit_result) {
+        return make_error(
+            body->runtime_evidence->span,
+            "function '" + display_decl_name(fn)
+                + "' body has runtime dependence not reflected in its return type: "
+                + body->runtime_evidence->reason);
     }
 
     // Check that body type matches declared return type (when a tail is present)
-    if (body->tail.has_value() && !compatible(body->ty, sig.return_ty)
+    if (body->tail.has_value() && !compatible(body->ty, sig.return_ty) && !implicit_unit_result
         && !should_defer_generic_probe_failure(body->ty, sig.return_ty, ctx))
         return make_error(
             fn.body->span, "function '" + display_decl_name(fn) + "' body type mismatch: expected '"

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -1395,13 +1395,32 @@ struct LoweredExpr {
 }
 
 [[nodiscard]] static bool stmt_value_is_ct_available(const tyir::TyStmt& stmt) {
+    auto expr_stmt_value_is_ct_available = [](const tyir::TyExprPtr& expr) {
+        if (expr == nullptr)
+            return false;
+
+        auto payload_is_ct_available = [](const std::optional<tyir::TyExprPtr>& value) {
+            return !value.has_value() || expr_value_is_ct_available(*value);
+        };
+
+        return std::visit(
+            [&](const auto& node) {
+                using N = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<N, tyir::TyBreak> || std::is_same_v<N, tyir::TyReturn>)
+                    return payload_is_ct_available(node.value);
+                else
+                    return expr_value_is_ct_available(expr);
+            },
+            expr->node);
+    };
+
     return std::visit(
-        [](const auto& s) {
+        [&](const auto& s) {
             using S = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
                 return expr_value_is_ct_available(s.init);
             else
-                return expr_value_is_ct_available(s.expr);
+                return expr_stmt_value_is_ct_available(s.expr);
         },
         stmt);
 }

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -3868,8 +3868,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                + "' may fall through without returning a value of type '"
                                + sig.return_ty.display() + "'");
 
-    if (fn.is_runtime)
+    if (fn.is_runtime) {
         body->ty.is_runtime = true;
+        recompute_block_summary(*body);
+    }
 
     auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
     auto lowered_constraints =

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -2805,6 +2805,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 seen_fields.reserve(node.fields.size());
                 bool fields_ct_available = true;
                 std::optional<tyir::TyRuntimeEvidence> fields_runtime_evidence;
+                bool fields_have_runtime_dependency = false;
 
                 for (const ast::StructInitField& field : node.fields) {
                     auto expected_ty = ctx.env.field_ty(type_name, field.name);
@@ -2830,7 +2831,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(resolved_val.error()));
                     val->expr = std::move(*resolved_val);
 
-                    if (!compatible(val->expr->ty, *expected_ty)
+                    if (!call_argument_compatible(val->expr->ty, *expected_ty)
                         && !should_defer_generic_probe_failure(val->expr->ty, *expected_ty, ctx))
                         return make_error(
                             field.span, "field '" + std::string(field.name.as_str())
@@ -2840,6 +2841,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     append_temp_borrows(temp_borrows, std::move(val->temp_borrows));
                     fields_ct_available =
                         fields_ct_available && expr_value_is_ct_available(val->expr);
+                    fields_have_runtime_dependency = fields_have_runtime_dependency
+                                                  || type_has_runtime_dependency(val->expr->ty);
                     fields_runtime_evidence = first_runtime_evidence(
                         fields_runtime_evidence, val->expr->runtime_evidence);
 
@@ -2856,11 +2859,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 + "' in struct initializer for '" + display_type_name + "'");
                 }
 
-                const tyir::Ty result_ty = annotate_type_semantics(
+                tyir::Ty result_ty = annotate_type_semantics(
                     tyir::ty::named(
                         type_name, node.display_name, tyir::ValueSemantics::Move, false,
                         lowered_generic_args),
                     ctx.env);
+                if (fields_have_runtime_dependency)
+                    result_ty.is_runtime = true;
                 auto lowered = LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -1544,11 +1544,11 @@ int main() {
     test_unreachable_runtime_statement_does_not_taint_block();
     test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call();
     test_whole_term_runtime_work_accepts_runtime_result_contract();
+    test_runtime_result_forwarded_param_does_not_count_as_hidden_work();
     test_runtime_function_accepts_whole_term_runtime_work();
     test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments();
     test_plain_call_lifts_runtime_arguments();
     test_plain_generic_call_accepts_runtime_argument_and_lifts_result();
-    test_runtime_result_forwarded_param_does_not_count_as_hidden_work();
     test_generic_runtime_result_forwarded_param_does_not_count_as_hidden_work();
     test_generic_call_lifts_runtime_arguments();
     test_plain_extern_call_accepts_runtime_argument_and_lifts_result();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -374,6 +374,26 @@ static void test_plain_generic_call_accepts_runtime_argument_and_lifts_result() 
     assert(call.args[0]->ty == ty::num(true));
 }
 
+static void test_runtime_result_forwarded_param_does_not_count_as_hidden_work() {
+    const auto prog = must_lower(
+        "fn id(value: num) -> num { value }"
+        "fn f(value: runtime num) -> runtime num { id(value) }");
+    const auto& fn = second_fn(prog);
+    assert(fn.body->ty == ty::num(true));
+    assert(!fn.body->ct_available);
+    assert(!fn.body->runtime_evidence.has_value());
+}
+
+static void test_generic_runtime_result_forwarded_param_does_not_count_as_hidden_work() {
+    const auto prog = must_lower(
+        "fn id<T>(value: T) -> T { value }"
+        "fn f(value: runtime num) -> runtime num { id(value) }");
+    const auto& fn = second_fn(prog);
+    assert(fn.body->ty == ty::num(true));
+    assert(!fn.body->ct_available);
+    assert(!fn.body->runtime_evidence.has_value());
+}
+
 static void test_plain_extern_call_accepts_runtime_argument_and_lifts_result() {
     const auto prog = must_lower(
         "runtime fn source() -> num { 1 }"
@@ -1528,6 +1548,8 @@ int main() {
     test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments();
     test_plain_call_lifts_runtime_arguments();
     test_plain_generic_call_accepts_runtime_argument_and_lifts_result();
+    test_runtime_result_forwarded_param_does_not_count_as_hidden_work();
+    test_generic_runtime_result_forwarded_param_does_not_count_as_hidden_work();
     test_generic_call_lifts_runtime_arguments();
     test_plain_extern_call_accepts_runtime_argument_and_lifts_result();
     test_runtime_argument_demotion_error();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -269,6 +269,22 @@ static void test_runtime_block_statement_taints_plain_result_function() {
         "function 'value' body has runtime dependence not reflected in its return type");
 }
 
+static void test_runtime_statement_marks_unit_block_not_ct_available() {
+    const auto prog = must_lower("fn value(x: runtime num) { x; }");
+    const auto& fn = first_fn(prog);
+    assert(fn.body->ty == ty::unit());
+    assert(!fn.body->ct_available);
+    assert(!fn.body->runtime_evidence.has_value());
+}
+
+static void test_unreachable_runtime_statement_does_not_taint_block() {
+    const auto prog = must_lower("fn value() -> num { return 1; runtime { 0 }; }");
+    const auto& fn = first_fn(prog);
+    assert(fn.body->ty == ty::never());
+    assert(fn.body->ct_available);
+    assert(!fn.body->runtime_evidence.has_value());
+}
+
 static void test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call() {
     must_fail_with_message(
         "runtime fn source() -> num { 1 }"
@@ -1484,6 +1500,8 @@ int main() {
     test_unused_runtime_let_taints_plain_result_function();
     test_runtime_expression_statement_taints_plain_result_function();
     test_runtime_block_statement_taints_plain_result_function();
+    test_runtime_statement_marks_unit_block_not_ct_available();
+    test_unreachable_runtime_statement_does_not_taint_block();
     test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call();
     test_whole_term_runtime_work_accepts_runtime_result_contract();
     test_runtime_function_accepts_whole_term_runtime_work();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -246,7 +246,7 @@ static void test_plain_call_lifted_result_still_prevents_return_demotion() {
         "runtime fn source() -> num { 1 }"
         "fn sink(value: num) -> num { value }"
         "fn main() -> num { sink(source()) }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_unused_runtime_let_taints_plain_result_function() {
@@ -337,7 +337,7 @@ static void test_runtime_argument_demotion_error() {
         "runtime fn source() -> num { 1 }"
         "fn sink(value: num) -> num { value }"
         "fn main() -> num { sink(source()) }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_plain_generic_call_accepts_runtime_argument_and_lifts_result() {
@@ -394,14 +394,14 @@ static void test_runtime_arithmetic_preserves_runtime_type() {
 static void test_runtime_arithmetic_prevents_demotion() {
     must_fail_with_message(
         "fn f() -> num { source() + 1 } runtime fn source() -> num { 1 }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_runtime_deferred_generic_return_prevents_demotion() {
     must_fail_with_message(
         "runtime fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn f() -> num { make_default(true) }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_runtime_comparison_preserves_runtime_type() {
@@ -425,7 +425,7 @@ static void test_runtime_logical_preserves_runtime_type() {
 static void test_runtime_logical_prevents_demotion() {
     must_fail_with_message(
         "fn f() -> bool { flag() && true } runtime fn flag() -> bool { true }",
-        "body type mismatch: expected 'bool', found 'runtime bool'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_runtime_block_promotes_pure_result() {
@@ -438,8 +438,7 @@ static void test_runtime_block_promotes_pure_result() {
 
 static void test_runtime_block_prevents_demotion() {
     must_fail_with_message(
-        "fn f() -> num { runtime { 1 } }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "fn f() -> num { runtime { 1 } }", "runtime dependence not reflected in its return type");
 }
 
 // ─── Unary operators ─────────────────────────────────────────────────────────
@@ -502,8 +501,8 @@ static void test_if_condition_must_be_bool() { must_fail("fn f(x: num) { if x { 
 
 static void test_runtime_if_condition_accepted() {
     const auto prog = must_lower(
-        "fn f() -> num { if flag() { 1 } else { 2 } } runtime fn flag() -> bool { true }");
-    assert((*first_fn(prog).body->tail)->ty == ty::num());
+        "fn f() -> runtime num { if flag() { 1 } else { 2 } } runtime fn flag() -> bool { true }");
+    assert((*first_fn(prog).body->tail)->ty == ty::num(true));
 }
 
 static void test_if_else_runtime_join_produces_runtime_type() {
@@ -526,7 +525,7 @@ static void test_if_else_runtime_join_prevents_demotion() {
     must_fail_with_message(
         "fn choose(flag: bool) -> num { if flag { 1 } else { source() } }"
         "runtime fn source() -> num { 2 }",
-        "expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 // ─── Control flow ─────────────────────────────────────────────────────────────
@@ -555,7 +554,7 @@ static void test_runtime_while_condition_accepted() {
         must_lower("fn f() { while flag() { break; } } runtime fn flag() -> bool { true }");
     const auto& while_expr = *first_fn(prog).body->tail;
     assert(std::holds_alternative<TyWhile>(while_expr->node));
-    assert(while_expr->ty == ty::unit());
+    assert(while_expr->ty == ty::unit(true));
 }
 
 static void test_for_loop() {
@@ -595,7 +594,7 @@ static void test_runtime_for_condition_accepted() {
         must_lower("fn f() { for (; flag(); ) { break; } } runtime fn flag() -> bool { true }");
     const auto& for_expr = *first_fn(prog).body->tail;
     assert(std::holds_alternative<TyFor>(for_expr->node));
-    assert(for_expr->ty == ty::unit());
+    assert(for_expr->ty == ty::unit(true));
 }
 
 static void test_break_and_continue_are_never() {
@@ -698,7 +697,7 @@ static void test_loop_break_runtime_join_prevents_demotion() {
         "  }"
         "}"
         "runtime fn source() -> num { 2 }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 // ─── Break/continue outside loop ─────────────────────────────────────────────
@@ -1070,14 +1069,14 @@ static void test_if_branch_join_keeps_runtime_on_deferred_generic_call() {
     must_fail_with_message(
         "runtime fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn f(cond: bool) -> num { if cond { make_default(true) } else { 0 } }",
-        "body type mismatch: expected 'num', found 'runtime num'");
+        "runtime dependence not reflected in its return type");
 }
 
 static void test_expected_type_resolves_nested_deferred_generic_argument() {
     const auto prog = must_lower(
         "fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn pair<T>(left: T, right: T) -> T { left }"
-        "fn f() -> num { pair(1, make_default(true)) }");
+        "fn f() -> runtime num { pair(1, make_default(true)) }");
     const auto& tail = *nth_fn(prog, 2).body->tail;
     assert(tail->ty == ty::num());
     const auto& call = std::get<TyCall>(tail->node);
@@ -1095,7 +1094,7 @@ static void test_deferred_resolution_uses_specialized_parameter_type() {
         "fn make_default<T>(flag: bool) -> T { loop {} }"
         "fn wrap<T>(value: T) -> T { value }"
         "fn pair<T>(left: T, right: T) -> T { left }"
-        "fn f() -> num { pair(1, wrap(make_default(true))) }");
+        "fn f() -> runtime num { pair(1, wrap(make_default(true))) }");
     const auto& tail = *nth_fn(prog, 3).body->tail;
     assert(tail->ty == ty::num());
     const auto& outer = std::get<TyCall>(tail->node);

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -249,6 +249,65 @@ static void test_plain_call_lifted_result_still_prevents_return_demotion() {
         "body type mismatch: expected 'num', found 'runtime num'");
 }
 
+static void test_unused_runtime_let_taints_plain_result_function() {
+    must_fail_with_message(
+        "runtime fn source() -> num { 1 }"
+        "fn value() -> num { let unused: runtime num = source(); 1 }",
+        "function 'value' body has runtime dependence not reflected in its return type");
+}
+
+static void test_runtime_expression_statement_taints_plain_result_function() {
+    must_fail_with_message(
+        "runtime fn source() -> num { 1 }"
+        "fn value() -> num { source(); 1 }",
+        "function 'value' body has runtime dependence not reflected in its return type");
+}
+
+static void test_runtime_block_statement_taints_plain_result_function() {
+    must_fail_with_message(
+        "fn value() -> num { runtime { 1 }; 1 }",
+        "function 'value' body has runtime dependence not reflected in its return type");
+}
+
+static void test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call() {
+    must_fail_with_message(
+        "runtime fn source() -> num { 1 }"
+        "fn helper() -> num { source(); 1 }"
+        "fn reserve(count: !runtime num) -> num { count }"
+        "fn main() -> num { reserve(helper()) }",
+        "function 'helper' body has runtime dependence not reflected in its return type");
+}
+
+static void test_whole_term_runtime_work_accepts_runtime_result_contract() {
+    const auto prog = must_lower(
+        "runtime fn source() -> num { 1 }"
+        "fn value() -> runtime num { source(); 1 }");
+    const auto& fn = second_fn(prog);
+    assert(fn.body->ty == ty::num(true));
+    assert(!fn.body->ct_available);
+}
+
+static void test_runtime_function_accepts_whole_term_runtime_work() {
+    const auto prog = must_lower(
+        "runtime fn source() -> num { 1 }"
+        "runtime fn value() -> num { source(); 1 }");
+    const auto& fn = second_fn(prog);
+    assert(fn.return_ty == ty::num(true));
+    assert(fn.body->ty == ty::num(true));
+}
+
+static void test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments() {
+    const auto prog = must_lower(
+        "runtime fn source() -> num { 1 }"
+        "fn checked_add(a: num, b: num) -> num { let result = a + b; result }"
+        "fn main() { let static_value: num = checked_add(1, 2); "
+        "let dynamic_value: runtime num = checked_add(source(), 2); }");
+    const auto& static_stmt = std::get<TyLetStmt>(nth_fn(prog, 2).body->stmts[0]);
+    const auto& dynamic_stmt = std::get<TyLetStmt>(nth_fn(prog, 2).body->stmts[1]);
+    assert(static_stmt.init->ty == ty::num());
+    assert(dynamic_stmt.init->ty == ty::num(true));
+}
+
 static void test_plain_call_lifts_runtime_arguments() {
     const auto prog = must_lower(
         "fn main() { let value: runtime num = add(runtime { 1 }, runtime { 2 }); }"
@@ -1423,6 +1482,13 @@ int main() {
     test_runtime_argument_promotion();
     test_plain_call_accepts_runtime_argument_and_lifts_result();
     test_plain_call_lifted_result_still_prevents_return_demotion();
+    test_unused_runtime_let_taints_plain_result_function();
+    test_runtime_expression_statement_taints_plain_result_function();
+    test_runtime_block_statement_taints_plain_result_function();
+    test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call();
+    test_whole_term_runtime_work_accepts_runtime_result_contract();
+    test_runtime_function_accepts_whole_term_runtime_work();
+    test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments();
     test_plain_call_lifts_runtime_arguments();
     test_plain_generic_call_accepts_runtime_argument_and_lifts_result();
     test_generic_call_lifts_runtime_arguments();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -307,9 +307,13 @@ static void test_runtime_function_accepts_whole_term_runtime_work() {
     const auto prog = must_lower(
         "runtime fn source() -> num { 1 }"
         "runtime fn value() -> num { source(); 1 }");
+    const auto& source = first_fn(prog);
     const auto& fn = second_fn(prog);
+    assert(source.body->ty == ty::num(true));
+    assert(!source.body->ct_available);
     assert(fn.return_ty == ty::num(true));
     assert(fn.body->ty == ty::num(true));
+    assert(!fn.body->ct_available);
 }
 
 static void test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments() {

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -636,6 +636,22 @@ static void test_return_is_never() {
     assert(std::holds_alternative<TyReturn>(stmt.expr->node));
 }
 
+static void test_runtime_return_payload_marks_body_not_ct_available() {
+    const auto prog = must_lower("fn f(x: runtime num) -> runtime num { return x; }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(!body.ct_available);
+}
+
+static void test_runtime_break_payload_marks_loop_body_not_ct_available() {
+    const auto prog = must_lower("fn f(x: runtime num) -> runtime num { loop { break x; } }");
+    const auto& body = *first_fn(prog).body;
+    const auto& loop = std::get<TyLoop>((*body.tail)->node);
+    assert((*body.tail)->ty == ty::num(true));
+    assert(!body.ct_available);
+    assert(!loop.body->ct_available);
+}
+
 // ─── Loop/break type inference ────────────────────────────────────────────────
 
 static void test_loop_break_num_type() {
@@ -1546,6 +1562,8 @@ int main() {
     test_runtime_for_condition_accepted();
     test_break_and_continue_are_never();
     test_return_is_never();
+    test_runtime_return_payload_marks_body_not_ct_available();
+    test_runtime_break_payload_marks_loop_body_not_ct_available();
 
     // Loop/break type inference
     test_loop_break_num_type();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -1335,6 +1335,20 @@ static void test_struct_init() {
     assert(std::holds_alternative<TyStructInit>(tail->node));
 }
 
+static void test_struct_init_lifts_runtime_field() {
+    const auto prog = must_lower(
+        "runtime fn source() -> num { 1 }"
+        "struct Point { x: num, y: num }"
+        "fn f() -> runtime Point { Point { x: source(), y: 0 } }");
+    const auto& tail = *second_fn(prog).body->tail;
+    assert(
+        tail->ty == ty::named(Symbol::intern("Point"), kInvalidSymbol, ValueSemantics::Copy, true));
+    const auto& init = std::get<TyStructInit>(tail->node);
+    assert(init.fields.size() == 2);
+    assert(init.fields[0].value->ty == ty::num(true));
+    assert(init.fields[1].value->ty == ty::num());
+}
+
 static void test_generic_struct_init() {
     const auto prog = must_lower(
         "struct Box<T> { value: T }"
@@ -1389,6 +1403,15 @@ static void test_struct_init_field_type_error() {
     must_fail(
         "struct Point { x: num, y: num }"
         "fn f() -> Point { Point { x: true, y: 0 } }");
+}
+
+static void test_struct_init_runtime_field_prevents_demotion() {
+    must_fail_with_message(
+        "runtime fn source() -> num { 1 }"
+        "struct Point { x: num }"
+        "fn f() -> Point { Point { x: source() } }",
+        "function 'f' body has runtime dependence not reflected in its return type: runtime-result "
+        "call");
 }
 
 static void test_struct_init_unknown_field_error() {
@@ -1660,11 +1683,13 @@ int main() {
     test_enum_variant_ref();
     test_unknown_variant_error();
     test_struct_init();
+    test_struct_init_lifts_runtime_field();
     test_generic_struct_init();
     test_generic_struct_specialization_tracks_move_semantics();
     test_generic_struct_specialization_keeps_copy_semantics();
     test_generic_fn_return_reannotates_specialized_semantics();
     test_struct_init_field_type_error();
+    test_struct_init_runtime_field_prevents_demotion();
     test_struct_init_unknown_field_error();
     test_struct_init_duplicate_field_error();
     test_struct_init_missing_field_error();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -2600,7 +2600,7 @@ fn main() -> num {
 
 static void test_generic_where_runtime_loop_reports_runtime_only() {
     SymbolSession session;
-    const auto error = must_fail_to_fold_with_constraint_prelude(R"(
+    const auto error = must_fail_to_lower_with_constraint_prelude(R"(
 runtime fn runtime_true() -> bool {
     true
 }
@@ -2620,13 +2620,13 @@ fn main() -> num {
 }
 )");
 
-    assert(error.message.find("runtime-only behavior") != std::string::npos);
-    assert(error.message.find("function 'id'") != std::string::npos);
+    assert(error.message.find("runtime dependence not reflected") != std::string::npos);
+    assert(error.message.find("function 'loop_true'") != std::string::npos);
 }
 
 static void test_generic_where_runtime_while_reports_runtime_only() {
     SymbolSession session;
-    const auto error = must_fail_to_fold_with_constraint_prelude(R"(
+    const auto error = must_fail_to_lower_with_constraint_prelude(R"(
 runtime fn runtime_true() -> bool {
     true
 }
@@ -2647,8 +2647,8 @@ fn main() -> num {
 }
 )");
 
-    assert(error.message.find("runtime-only behavior") != std::string::npos);
-    assert(error.message.find("function 'id'") != std::string::npos);
+    assert(error.message.find("runtime dependence not reflected") != std::string::npos);
+    assert(error.message.find("function 'while_true'") != std::string::npos);
 }
 
 static void test_unused_generic_where_is_deferred_until_instantiation() {

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -412,6 +412,19 @@ fn f(b: bool) -> num {
 }
 ```
 
+Block availability is a whole-term property. Every statement that is lowered for
+the block contributes its expression availability, even if the statement's value
+is discarded or a `let` binding is never read later. The block result is
+runtime-qualified when a statement, condition, loop header, runtime block, or
+tail expression contains body-internal runtime dependence.
+
+Plain helpers remain reusable with compile-time or runtime arguments: ordinary
+parameter dependence is handled at call sites by lifting the call result when an
+actual argument is runtime-qualified. What must be exposed in a function contract
+is runtime dependence introduced inside the body itself. An explicit plain return
+annotation rejects such hidden runtime work; use `runtime fn`, `-> runtime T`, or
+an explicit runtime boundary when the runtime behavior is intentional.
+
 ## 7. Valid Syntax Examples
 
 ```text

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -412,11 +412,11 @@ fn f(b: bool) -> num {
 }
 ```
 
-Block availability is a whole-term property. Every statement that is lowered for
-the block contributes its expression availability, even if the statement's value
-is discarded or a `let` binding is never read later. The block result is
-runtime-qualified when a statement, condition, loop header, runtime block, or
-tail expression contains body-internal runtime dependence.
+Block availability is a whole-term property. Every reachable statement in the
+block contributes its expression availability, even if the statement's value is
+discarded or a `let` binding is never read later. The block result is
+runtime-qualified when a reachable statement, condition, loop header, runtime
+block, or tail expression contains body-internal runtime dependence.
 
 Plain helpers remain reusable with compile-time or runtime arguments: ordinary
 parameter dependence is handled at call sites by lifting the call result when an

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -63,11 +63,12 @@ preserves the original declaration-level runtime marker on function items for
 later passes such as const-eval.
 
 TyIR also records body-internal runtime evidence separately from ordinary
-parameter availability. This evidence is joined across all lowered statements,
-control-flow headers, branch bodies, loop bodies, and the tail expression. If a
-function has an explicit plain result contract, that evidence must be reflected by
-`runtime fn` or a runtime-qualified return type; ordinary parameter dependence is
-still accepted because call-site lifting accounts for the actual arguments.
+parameter availability. This evidence is joined across reachable lowered
+statements, control-flow headers, branch bodies, loop bodies, and the tail
+expression. If a function has an explicit plain result contract, that evidence
+must be reflected by `runtime fn` or a runtime-qualified return type; ordinary
+parameter dependence is still accepted because call-site lifting accounts for the
+actual arguments.
 
 ## Generics and constraints
 
@@ -129,10 +130,11 @@ A `TyBlock` has type:
 - The tail expression's type when a tail is present.
 - `Unit` when there is no tail expression.
 
-Its `ct_available` flag is whole-term: it joins statement contributions and the
-tail expression rather than considering only the yielded value. `runtime_evidence`
-stores the first body-internal runtime contributor so diagnostics can point at
-the non-tail statement or control-flow component that tainted the block.
+Its `ct_available` flag is whole-term: it joins reachable statement
+contributions and the tail expression rather than considering only the yielded
+value. `runtime_evidence` stores the first reachable body-internal runtime
+contributor so diagnostics can point at the non-tail statement or control-flow
+component that tainted the block.
 
 ## Runtime block type rules
 

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -62,6 +62,13 @@ normalized during lowering into a runtime-tagged return type, and TyIR also
 preserves the original declaration-level runtime marker on function items for
 later passes such as const-eval.
 
+TyIR also records body-internal runtime evidence separately from ordinary
+parameter availability. This evidence is joined across all lowered statements,
+control-flow headers, branch bodies, loop bodies, and the tail expression. If a
+function has an explicit plain result contract, that evidence must be reflected by
+`runtime fn` or a runtime-qualified return type; ordinary parameter dependence is
+still accepted because call-site lifting accounts for the actual arguments.
+
 ## Generics and constraints
 
 TyIR is the last IR that may still contain generic declarations.
@@ -121,6 +128,11 @@ TyReturn         — return [value]          → type: !
 A `TyBlock` has type:
 - The tail expression's type when a tail is present.
 - `Unit` when there is no tail expression.
+
+Its `ct_available` flag is whole-term: it joins statement contributions and the
+tail expression rather than considering only the yielded value. `runtime_evidence`
+stores the first body-internal runtime contributor so diagnostics can point at
+the non-tail statement or control-flow component that tainted the block.
 
 ## Runtime block type rules
 

--- a/test/availability_evidence/diagnostics/plain_call_forwarded_runtime_param_demotion.patterns
+++ b/test/availability_evidence/diagnostics/plain_call_forwarded_runtime_param_demotion.patterns
@@ -1,0 +1,5 @@
+# source: test/e2e/fail_compile/type_errors/plain_call_forwarded_runtime_param_demotion.cst
+# rule: forwarded_runtime_parameter_demotion
+function 'forward_plain' body type mismatch
+expected 'num'
+found 'runtime num'

--- a/test/availability_evidence/diagnostics/runtime_join_demotion.patterns
+++ b/test/availability_evidence/diagnostics/runtime_join_demotion.patterns
@@ -1,5 +1,5 @@
 # source: test/e2e/fail_compile/type_errors/runtime_join_demotion.cst
 # rule: rejected_reverse_demotion
 function 'main' body
-expected 'num'
-found 'runtime num'
+runtime dependence not reflected in its return type
+runtime-result call

--- a/test/availability_evidence/diagnostics/struct_literal_runtime_field_demotion.patterns
+++ b/test/availability_evidence/diagnostics/struct_literal_runtime_field_demotion.patterns
@@ -1,0 +1,5 @@
+# source: test/e2e/fail_compile/type_errors/struct_literal_runtime_field_demotion.cst
+# rule: struct_literal_runtime_field_demotion
+function 'make_point' body
+runtime dependence not reflected in its return type
+runtime-result call

--- a/test/e2e/fail_compile/type_errors/plain_call_forwarded_runtime_param_demotion.cst
+++ b/test/e2e/fail_compile/type_errors/plain_call_forwarded_runtime_param_demotion.cst
@@ -1,0 +1,9 @@
+fn id(value: num) -> num { value }
+
+fn forward_plain(value: runtime num) -> num {
+    id(value)
+}
+
+fn main() -> num {
+    forward_plain(runtime { 1 })
+}

--- a/test/e2e/fail_compile/type_errors/struct_literal_runtime_field_demotion.cst
+++ b/test/e2e/fail_compile/type_errors/struct_literal_runtime_field_demotion.cst
@@ -1,0 +1,11 @@
+runtime fn source() -> num { 1 }
+
+struct Point { x: num }
+
+fn make_point() -> Point {
+    Point { x: source() }
+}
+
+fn main() {
+    let _ = make_point();
+}

--- a/test/e2e/fail_compile/type_errors/whole_term_hidden_runtime_ct_required.cst
+++ b/test/e2e/fail_compile/type_errors/whole_term_hidden_runtime_ct_required.cst
@@ -1,0 +1,14 @@
+runtime fn source() -> num { 1 }
+
+fn helper() -> num {
+    source();
+    1
+}
+
+fn reserve(count: !runtime num) -> num {
+    count
+}
+
+fn main() -> num {
+    reserve(helper())
+}

--- a/test/e2e/fail_compile/type_errors/whole_term_runtime_block_stmt.cst
+++ b/test/e2e/fail_compile/type_errors/whole_term_runtime_block_stmt.cst
@@ -1,0 +1,8 @@
+fn value() -> num {
+    runtime { 1 };
+    1
+}
+
+fn main() -> num {
+    value()
+}

--- a/test/e2e/fail_compile/type_errors/whole_term_runtime_expr_stmt.cst
+++ b/test/e2e/fail_compile/type_errors/whole_term_runtime_expr_stmt.cst
@@ -1,0 +1,10 @@
+runtime fn source() -> num { 1 }
+
+fn value() -> num {
+    source();
+    1
+}
+
+fn main() -> num {
+    value()
+}

--- a/test/e2e/fail_compile/type_errors/whole_term_unused_runtime_let.cst
+++ b/test/e2e/fail_compile/type_errors/whole_term_unused_runtime_let.cst
@@ -1,0 +1,10 @@
+runtime fn source() -> num { 1 }
+
+fn value() -> num {
+    let unused: runtime num = source();
+    1
+}
+
+fn main() -> num {
+    value()
+}

--- a/test/e2e/pass/runtime/plain_call_forwarded_runtime_param.cst
+++ b/test/e2e/pass/runtime/plain_call_forwarded_runtime_param.cst
@@ -1,0 +1,18 @@
+fn id(value: num) -> num { value }
+
+fn generic_id<T>(value: T) -> T { value }
+
+fn forward_plain(value: runtime num) -> runtime num {
+    id(value)
+}
+
+fn forward_generic(value: runtime num) -> runtime num {
+    generic_id(value)
+}
+
+fn main() {
+    let plain: runtime num = forward_plain(runtime { 1 });
+    let generic: runtime num = forward_generic(runtime { 2 });
+    let _ = plain;
+    let _ = generic;
+}

--- a/test/e2e/pass/runtime/struct_literal_runtime_field.cst
+++ b/test/e2e/pass/runtime/struct_literal_runtime_field.cst
@@ -1,0 +1,13 @@
+runtime fn source() -> num { 1 }
+
+struct Point { x: num, y: num }
+
+fn make_point() -> runtime Point {
+    Point { x: source(), y: 0 }
+}
+
+fn main() {
+    let point: runtime Point = make_point();
+    let x: runtime num = point.x;
+    let _ = x;
+}

--- a/test/e2e/pass/runtime/whole_term_runtime_result.cst
+++ b/test/e2e/pass/runtime/whole_term_runtime_result.cst
@@ -1,0 +1,27 @@
+runtime fn source() -> num { 1 }
+
+fn value() -> runtime num {
+    source();
+    1
+}
+
+runtime fn runtime_value() -> num {
+    source();
+    1
+}
+
+fn checked_add(a: num, b: num) -> num {
+    let result = a + b;
+    result
+}
+
+fn main() {
+    let static_value: num = checked_add(1, 2);
+    let dynamic_value: runtime num = checked_add(source(), 2);
+    let explicit_runtime: runtime num = value();
+    let runtime_fn_value: runtime num = runtime_value();
+    let _ = static_value;
+    let _ = dynamic_value;
+    let _ = explicit_runtime;
+    let _ = runtime_fn_value;
+}

--- a/test/e2e/pass/runtime/whole_term_runtime_result.cst
+++ b/test/e2e/pass/runtime/whole_term_runtime_result.cst
@@ -15,13 +15,29 @@ fn checked_add(a: num, b: num) -> num {
     result
 }
 
+fn id(value: num) -> num { value }
+
+fn forward_runtime_arg(value: runtime num) -> runtime num {
+    id(value)
+}
+
+fn generic_id<T>(value: T) -> T { value }
+
+fn forward_runtime_arg_generic(value: runtime num) -> runtime num {
+    generic_id(value)
+}
+
 fn main() {
     let static_value: num = checked_add(1, 2);
     let dynamic_value: runtime num = checked_add(source(), 2);
     let explicit_runtime: runtime num = value();
     let runtime_fn_value: runtime num = runtime_value();
+    let forwarded_runtime: runtime num = forward_runtime_arg(source());
+    let generic_forwarded_runtime: runtime num = forward_runtime_arg_generic(source());
     let _ = static_value;
     let _ = dynamic_value;
     let _ = explicit_runtime;
     let _ = runtime_fn_value;
+    let _ = forwarded_runtime;
+    let _ = generic_forwarded_runtime;
 }


### PR DESCRIPTION
Closes #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocks now track body-internal runtime evidence and that metadata affects compile-time availability; lowering enforces runtime work be exposed via runtime signatures or explicit boundaries.

* **Improved Error Messages**
  * Consolidated diagnostics report when runtime dependence inside a body is not reflected in its return contract.

* **Documentation**
  * Language and IR docs updated to explain block availability, runtime evidence, and exposure rules.

* **Tests**
  * Expanded unit and E2E tests to cover propagation, CT availability, and failure/acceptance scenarios for runtime evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->