### PR TITLE
refactor: refactor TyIR to use canonical availability summary

### DIFF
--- a/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
+++ b/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
@@ -512,8 +512,6 @@ static void test_never_call_seals_block() {
         std::nullopt,
         cstc::tyir::ty::never(),
         span,
-        true,
-        std::nullopt,
         cstc::tyir::availability_ct(),
     });
     const auto if_expr = cstc::tyir::make_ty_expr(
@@ -534,8 +532,6 @@ static void test_never_call_seals_block() {
         tail,
         cstc::tyir::ty::num(),
         span,
-        true,
-        std::nullopt,
         cstc::tyir::availability_ct(),
     });
     ty_fn.span = span;

--- a/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
+++ b/compiler/cstc_lir_builder/tests/lower_control_flow.cpp
@@ -514,6 +514,7 @@ static void test_never_call_seals_block() {
         span,
         true,
         std::nullopt,
+        cstc::tyir::availability_ct(),
     });
     const auto if_expr = cstc::tyir::make_ty_expr(
         span, cstc::tyir::TyIf{cond, then_block, std::nullopt}, cstc::tyir::ty::unit());
@@ -535,6 +536,7 @@ static void test_never_call_seals_block() {
         span,
         true,
         std::nullopt,
+        cstc::tyir::availability_ct(),
     });
     ty_fn.span = span;
     ty_fn.is_runtime = false;

--- a/compiler/cstc_lir_builder/tests/lower_fns.cpp
+++ b/compiler/cstc_lir_builder/tests/lower_fns.cpp
@@ -121,7 +121,7 @@ static void test_temporaries_are_unnamed() {
     // Look for a local without a debug name that is num-typed.
     bool found_temp = false;
     for (const LirLocalDecl& loc : fn.locals) {
-        if (!loc.debug_name.has_value() && loc.ty == cstc::tyir::ty::num(true)) {
+        if (!loc.debug_name.has_value() && loc.ty == cstc::tyir::ty::num()) {
             found_temp = true;
             break;
         }

--- a/compiler/cstc_lir_builder/tests/lower_fns.cpp
+++ b/compiler/cstc_lir_builder/tests/lower_fns.cpp
@@ -121,7 +121,7 @@ static void test_temporaries_are_unnamed() {
     // Look for a local without a debug name that is num-typed.
     bool found_temp = false;
     for (const LirLocalDecl& loc : fn.locals) {
-        if (!loc.debug_name.has_value() && loc.ty == cstc::tyir::ty::num()) {
+        if (!loc.debug_name.has_value() && loc.ty == cstc::tyir::ty::num(true)) {
             found_temp = true;
             break;
         }

--- a/compiler/cstc_tyir/README.md
+++ b/compiler/cstc_tyir/README.md
@@ -156,11 +156,11 @@ TyProgram
     x: num
     y: num
   TyFnDecl add(x: num, y: num) -> num
-    TyBlock: num
+    TyBlock: num [availability: CT]
       Tail
-        TyBinary(+): num
-          TyLocal(x): num
-          TyLocal(y): num
+        TyBinary(+): num [availability: CT]
+          TyLocal(x): num [availability: CT]
+          TyLocal(y): num [availability: CT]
 ```
 
 ## Dependencies

--- a/compiler/cstc_tyir/README.md
+++ b/compiler/cstc_tyir/README.md
@@ -66,14 +66,11 @@ struct Availability {
 };
 ```
 
-Every expression and block carries a canonical availability summary. `Ct` means
-the value can be used during compile-time evaluation. `Rt` means the value depends
-on a runtime-qualified source, a runtime-result declaration, a runtime block, or a
-whole-term runtime contribution. `evidence` records the first concrete runtime
-origin when one is available for diagnostics.
-
-`Ty::is_runtime`, `ct_available`, and `runtime_evidence` remain as compatibility
-projections while older consumers migrate to `availability`.
+Every expression and block carries this canonical availability summary directly.
+`Ct` means the value can be used during compile-time evaluation. `Rt` means the
+value depends on a runtime-qualified source, a runtime-result declaration, a
+runtime block, or a whole-term runtime contribution. `evidence` records the first
+concrete runtime origin when one is available for diagnostics.
 
 ### `TyExpr` — type-annotated expression
 
@@ -113,16 +110,13 @@ struct TyBlock {
     std::optional<TyExprPtr> tail;
     Ty ty;   // = tail->ty when tail exists; else Unit or Never (by fallthrough)
     SourceSpan span;
-    bool ct_available;
-    std::optional<TyRuntimeEvidence> runtime_evidence;
     Availability availability;
 };
 ```
 
 `availability` is computed from the whole reachable block term, not just the tail
 value. Reachable statement initializers, expression statements, control-flow
-headers, loop bodies, and the tail all contribute. The legacy `ct_available` and
-`runtime_evidence` fields are derived shims.
+headers, loop bodies, and the tail all contribute.
 
 ### Item declarations
 
@@ -156,11 +150,11 @@ TyProgram
     x: num
     y: num
   TyFnDecl add(x: num, y: num) -> num
-    TyBlock: num [availability: CT]
+    TyBlock: num [availability: const]
       Tail
-        TyBinary(+): num [availability: CT]
-          TyLocal(x): num [availability: CT]
-          TyLocal(y): num [availability: CT]
+        TyBinary(+): num [availability: const]
+          TyLocal(x): num [availability: const]
+          TyLocal(y): num [availability: const]
 ```
 
 ## Dependencies

--- a/compiler/cstc_tyir/README.md
+++ b/compiler/cstc_tyir/README.md
@@ -22,6 +22,7 @@ which performs name resolution and type checking during the lowering pass.
 | Name resolution | Raw `PathExpr` symbols | `LocalRef`, `EnumVariantRef`, `fn_name` in `TyCall` |
 | Type checking | None | Verified during lowering |
 | Operator validity | Syntactic | Operand types validated |
+| Availability | Implicit in syntax | Canonical `Availability` summary on expressions and blocks |
 
 ## Key types
 
@@ -54,12 +55,33 @@ wrapper-shaped type such as `Runtime<T>`: it keeps the same underlying type
 shape as `T`, but its tag participates in exact type identity and in the
 directional promotion rule `T -> runtime T`.
 
+### `Availability` — compile-time/runtime summary
+
+```cpp
+enum class AvailabilityKind { Ct, Rt };
+
+struct Availability {
+    AvailabilityKind kind;
+    std::optional<TyRuntimeEvidence> evidence;
+};
+```
+
+Every expression and block carries a canonical availability summary. `Ct` means
+the value can be used during compile-time evaluation. `Rt` means the value depends
+on a runtime-qualified source, a runtime-result declaration, a runtime block, or a
+whole-term runtime contribution. `evidence` records the first concrete runtime
+origin when one is available for diagnostics.
+
+`Ty::is_runtime`, `ct_available`, and `runtime_evidence` remain as compatibility
+projections while older consumers migrate to `availability`.
+
 ### `TyExpr` — type-annotated expression
 
 Every expression node carries:
 - `node` — one of the concrete expression variants
 - `ty`   — the resolved `Ty`
 - `span` — source location
+- `availability` — canonical compile-time/runtime availability summary
 
 Concrete expression variants:
 
@@ -93,14 +115,14 @@ struct TyBlock {
     SourceSpan span;
     bool ct_available;
     std::optional<TyRuntimeEvidence> runtime_evidence;
+    Availability availability;
 };
 ```
 
-`ct_available` is computed from the whole reachable block term, not just the tail
+`availability` is computed from the whole reachable block term, not just the tail
 value. Reachable statement initializers, expression statements, control-flow
-headers, loop bodies, and the tail all contribute. `runtime_evidence` records the
-first reachable body-internal runtime contributor that must be exposed by an
-explicit runtime result contract.
+headers, loop bodies, and the tail all contribute. The legacy `ct_available` and
+`runtime_evidence` fields are derived shims.
 
 ### Item declarations
 

--- a/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
@@ -62,6 +62,26 @@ inline void indent(std::ostringstream& out, std::size_t level) {
     return "";
 }
 
+[[nodiscard]] inline std::string_view availability_name(AvailabilityKind kind) {
+    switch (kind) {
+    case AvailabilityKind::Ct: return "CT";
+    case AvailabilityKind::Rt: return "RT";
+    }
+    return "?";
+}
+
+[[nodiscard]] inline std::string availability_suffix(const Availability& availability) {
+    return " [availability: " + std::string(availability_name(availability.kind)) + "]";
+}
+
+[[nodiscard]] inline std::string expr_type_summary(const TyExprPtr& expr) {
+    return expr->ty.display() + availability_suffix(expr->availability);
+}
+
+[[nodiscard]] inline std::string block_type_summary(const TyBlockPtr& block) {
+    return block->ty.display() + availability_suffix(block->availability);
+}
+
 [[nodiscard]] inline std::string param_type_name(const TyParam& param) {
     if (param.requires_ct())
         return "!runtime " + param.ty.display();
@@ -93,7 +113,7 @@ inline void print_ty_block(std::ostringstream& out, const TyBlockPtr& block, std
 
 inline void print_ty_block(std::ostringstream& out, const TyBlockPtr& block, std::size_t level) {
     indent(out, level);
-    out << "TyBlock: " << block->ty.display() << "\n";
+    out << "TyBlock: " << block_type_summary(block) << "\n";
 
     for (const TyStmt& stmt : block->stmts) {
         std::visit(
@@ -132,33 +152,33 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 switch (node.kind) {
                 case TyLiteral::Kind::Num:
                 case TyLiteral::Kind::Str:
-                    out << "TyLiteral(" << node.symbol.as_str() << "): " << expr->ty.display()
+                    out << "TyLiteral(" << node.symbol.as_str() << "): " << expr_type_summary(expr)
                         << "\n";
                     break;
                 case TyLiteral::Kind::OwnedStr:
-                    out << "TyLiteral(owned " << node.symbol.as_str() << "): " << expr->ty.display()
-                        << "\n";
+                    out << "TyLiteral(owned " << node.symbol.as_str()
+                        << "): " << expr_type_summary(expr) << "\n";
                     break;
                 case TyLiteral::Kind::Bool:
                     out << "TyLiteral(" << (node.bool_value ? "true" : "false")
-                        << "): " << expr->ty.display() << "\n";
+                        << "): " << expr_type_summary(expr) << "\n";
                     break;
                 case TyLiteral::Kind::Unit:
-                    out << "TyLiteral(()): " << expr->ty.display() << "\n";
+                    out << "TyLiteral(()): " << expr_type_summary(expr) << "\n";
                     break;
                 }
             } else if constexpr (std::is_same_v<N, LocalRef>) {
                 indent(out, level);
                 out << "TyLocal(" << node.name.as_str() << ")" << use_kind_suffix(node.use_kind)
-                    << ": " << expr->ty.display() << "\n";
+                    << ": " << expr_type_summary(expr) << "\n";
             } else if constexpr (std::is_same_v<N, EnumVariantRef>) {
                 indent(out, level);
                 out << "TyVariant(" << node.enum_name.as_str() << "::" << node.variant_name.as_str()
-                    << "): " << expr->ty.display() << "\n";
+                    << "): " << expr_type_summary(expr) << "\n";
             } else if constexpr (std::is_same_v<N, TyStructInit>) {
                 indent(out, level);
-                out << "TyStructInit(" << node.type_name.as_str() << "): " << expr->ty.display()
-                    << "\n";
+                out << "TyStructInit(" << node.type_name.as_str()
+                    << "): " << expr_type_summary(expr) << "\n";
                 if (!node.generic_args.empty()) {
                     indent(out, level + 1);
                     out << "GenericArgs\n";
@@ -174,25 +194,28 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 }
             } else if constexpr (std::is_same_v<N, TyBorrow>) {
                 indent(out, level);
-                out << "TyBorrow: " << expr->ty.display() << "\n";
+                out << "TyBorrow: " << expr_type_summary(expr) << "\n";
                 print_ty_expr(out, node.rhs, level + 1);
             } else if constexpr (std::is_same_v<N, TyUnary>) {
                 indent(out, level);
-                out << "TyUnary(" << unary_name(node.op) << "): " << expr->ty.display() << "\n";
+                out << "TyUnary(" << unary_name(node.op) << "): " << expr_type_summary(expr)
+                    << "\n";
                 print_ty_expr(out, node.rhs, level + 1);
             } else if constexpr (std::is_same_v<N, TyBinary>) {
                 indent(out, level);
-                out << "TyBinary(" << binary_name(node.op) << "): " << expr->ty.display() << "\n";
+                out << "TyBinary(" << binary_name(node.op) << "): " << expr_type_summary(expr)
+                    << "\n";
                 print_ty_expr(out, node.lhs, level + 1);
                 print_ty_expr(out, node.rhs, level + 1);
             } else if constexpr (std::is_same_v<N, TyFieldAccess>) {
                 indent(out, level);
                 out << "TyFieldAccess(." << node.field.as_str() << ")"
-                    << use_kind_suffix(node.use_kind) << ": " << expr->ty.display() << "\n";
+                    << use_kind_suffix(node.use_kind) << ": " << expr_type_summary(expr) << "\n";
                 print_ty_expr(out, node.base, level + 1);
             } else if constexpr (std::is_same_v<N, TyCall>) {
                 indent(out, level);
-                out << "TyCall(" << node.fn_name.as_str() << "): " << expr->ty.display() << "\n";
+                out << "TyCall(" << node.fn_name.as_str() << "): " << expr_type_summary(expr)
+                    << "\n";
                 if (!node.generic_args.empty()) {
                     indent(out, level + 1);
                     out << "GenericArgs\n";
@@ -209,7 +232,7 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
             } else if constexpr (std::is_same_v<N, TyDeferredGenericCall>) {
                 indent(out, level);
                 out << "TyDeferredGenericCall(" << node.fn_name.as_str()
-                    << "): " << expr->ty.display() << "\n";
+                    << "): " << expr_type_summary(expr) << "\n";
                 if (!node.generic_args.empty()) {
                     indent(out, level + 1);
                     out << "GenericArgs\n";
@@ -225,7 +248,7 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 }
             } else if constexpr (std::is_same_v<N, TyDeclProbe>) {
                 indent(out, level);
-                out << "TyDeclProbe: " << expr->ty.display();
+                out << "TyDeclProbe: " << expr_type_summary(expr);
                 if (node.is_invalid)
                     out << " [invalid]";
                 out << "\n";
@@ -233,13 +256,13 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                     print_ty_expr(out, *node.expr, level + 1);
             } else if constexpr (std::is_same_v<N, TyRuntimeBlock>) {
                 indent(out, level);
-                out << "TyRuntimeBlock: " << expr->ty.display() << "\n";
+                out << "TyRuntimeBlock: " << expr_type_summary(expr) << "\n";
                 print_ty_block(out, node.body, level + 1);
             } else if constexpr (std::is_same_v<N, TyBlockPtr>) {
                 print_ty_block(out, node, level);
             } else if constexpr (std::is_same_v<N, TyIf>) {
                 indent(out, level);
-                out << "TyIf: " << expr->ty.display() << "\n";
+                out << "TyIf: " << expr_type_summary(expr) << "\n";
                 indent(out, level + 1);
                 out << "Condition\n";
                 print_ty_expr(out, node.condition, level + 2);
@@ -253,11 +276,11 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 }
             } else if constexpr (std::is_same_v<N, TyLoop>) {
                 indent(out, level);
-                out << "TyLoop: " << expr->ty.display() << "\n";
+                out << "TyLoop: " << expr_type_summary(expr) << "\n";
                 print_ty_block(out, node.body, level + 1);
             } else if constexpr (std::is_same_v<N, TyWhile>) {
                 indent(out, level);
-                out << "TyWhile: " << expr->ty.display() << "\n";
+                out << "TyWhile: " << expr_type_summary(expr) << "\n";
                 indent(out, level + 1);
                 out << "Condition\n";
                 print_ty_expr(out, node.condition, level + 2);
@@ -266,7 +289,7 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 print_ty_block(out, node.body, level + 2);
             } else if constexpr (std::is_same_v<N, TyFor>) {
                 indent(out, level);
-                out << "TyFor: " << expr->ty.display() << "\n";
+                out << "TyFor: " << expr_type_summary(expr) << "\n";
                 if (node.init.has_value()) {
                     const TyForInit& init = *node.init;
                     indent(out, level + 1);
@@ -293,15 +316,15 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 print_ty_block(out, node.body, level + 2);
             } else if constexpr (std::is_same_v<N, TyBreak>) {
                 indent(out, level);
-                out << "TyBreak: !\n";
+                out << "TyBreak: " << expr_type_summary(expr) << "\n";
                 if (node.value.has_value())
                     print_ty_expr(out, *node.value, level + 1);
             } else if constexpr (std::is_same_v<N, TyContinue>) {
                 indent(out, level);
-                out << "TyContinue: !\n";
+                out << "TyContinue: " << expr_type_summary(expr) << "\n";
             } else if constexpr (std::is_same_v<N, TyReturn>) {
                 indent(out, level);
-                out << "TyReturn: !\n";
+                out << "TyReturn: " << expr_type_summary(expr) << "\n";
                 if (node.value.has_value())
                     print_ty_expr(out, *node.value, level + 1);
             }

--- a/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
@@ -64,8 +64,8 @@ inline void indent(std::ostringstream& out, std::size_t level) {
 
 [[nodiscard]] inline std::string_view availability_name(AvailabilityKind kind) {
     switch (kind) {
-    case AvailabilityKind::Ct: return "CT";
-    case AvailabilityKind::Rt: return "RT";
+    case AvailabilityKind::Ct: return "const";
+    case AvailabilityKind::Rt: return "runtime";
     }
     return "?";
 }

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -198,6 +199,22 @@ struct Ty {
     }
 };
 
+/// Returns true when `ty` or any nested type argument/pointee carries the
+/// source-level `runtime` qualifier.
+[[nodiscard]] inline bool ty_contains_runtime_tag(const Ty& ty) {
+    if (ty.is_runtime)
+        return true;
+    if (ty.kind == TyKind::Ref)
+        return ty.pointee != nullptr && ty_contains_runtime_tag(*ty.pointee);
+    if (ty.kind != TyKind::Named)
+        return false;
+    for (const Ty& arg : ty.generic_args) {
+        if (ty_contains_runtime_tag(arg))
+            return true;
+    }
+    return false;
+}
+
 /// Factory helpers for the well-known primitive types.
 namespace ty {
 /// Unit type `()`.
@@ -335,6 +352,78 @@ struct TyRuntimeEvidence {
     /// Short diagnostic description of the contributor.
     std::string reason;
 };
+
+/// Canonical compile-time/runtime availability classification for a TyIR value.
+enum class AvailabilityKind {
+    /// The value is known to be available during compile-time evaluation.
+    Ct,
+    /// The value depends on runtime input or a runtime authorization boundary.
+    Rt,
+};
+
+/// Canonical TyIR availability summary.
+///
+/// `evidence` records the first concrete runtime origin when one is known. A
+/// runtime-qualified source type can make an expression `Rt` without producing a
+/// body-internal diagnostic evidence span.
+struct Availability {
+    /// Availability lattice point for the expression or block.
+    AvailabilityKind kind = AvailabilityKind::Ct;
+    /// First concrete runtime contributor, when available.
+    std::optional<TyRuntimeEvidence> evidence;
+};
+
+/// Compile-time-available summary.
+[[nodiscard]] inline Availability availability_ct() { return {}; }
+
+/// Runtime-dependent summary, optionally carrying first-origin evidence.
+[[nodiscard]] inline Availability
+    availability_rt(std::optional<TyRuntimeEvidence> evidence = std::nullopt) {
+    return Availability{AvailabilityKind::Rt, std::move(evidence)};
+}
+
+/// Joins two availability summaries; runtime wins and the first concrete
+/// evidence is preserved.
+[[nodiscard]] inline Availability
+    availability_join(const Availability& lhs, const Availability& rhs) {
+    if (lhs.kind == AvailabilityKind::Ct)
+        return rhs;
+    if (rhs.kind == AvailabilityKind::Ct)
+        return lhs;
+    return Availability{
+        AvailabilityKind::Rt, lhs.evidence.has_value() ? lhs.evidence : rhs.evidence};
+}
+
+/// Projects a source/runtime-qualified type into an availability summary.
+[[nodiscard]] inline Availability
+    availability_from_type(const Ty& ty, cstc::span::SourceSpan span = {}) {
+    (void)span;
+    return ty_contains_runtime_tag(ty) ? availability_rt() : availability_ct();
+}
+
+/// Converts legacy split fields into the canonical availability summary.
+[[nodiscard]] inline Availability availability_from_legacy(
+    const Ty& ty, cstc::span::SourceSpan span, bool ct_available,
+    const std::optional<TyRuntimeEvidence>& runtime_evidence = std::nullopt) {
+    Availability availability = availability_from_type(ty, span);
+    if (!ct_available || runtime_evidence.has_value())
+        availability = availability_join(availability, availability_rt(runtime_evidence));
+    return availability;
+}
+
+/// Applies an availability summary to a type used for expression display or
+/// lowering decisions.
+[[nodiscard]] inline Ty with_availability_projection(Ty shape, const Availability& availability) {
+    if (shape.is_never())
+        return shape;
+    shape.is_runtime = availability.kind == AvailabilityKind::Rt;
+    return shape;
+}
+
+/// Returns true when the canonical availability summary is compile-time.
+[[nodiscard]] inline bool is_ct_available(const Availability& availability) {
+    return availability.kind == AvailabilityKind::Ct;
+}
 
 /// Single named-field initializer inside a struct construction expression.
 struct TyStructInitField {
@@ -509,8 +598,7 @@ struct TyReturn {
 /// - `node`: the concrete expression variant,
 /// - `ty`:   the inferred or annotated type,
 /// - `span`: the source location,
-/// - `ct_available`: whether the expression value is guaranteed available at
-///   compile time, independent of the static type shape.
+/// - `availability`: canonical compile-time/runtime availability for the value.
 struct TyExpr {
     /// Variant payload for all typed expression forms.
     using Node = std::variant<
@@ -524,18 +612,51 @@ struct TyExpr {
     Ty ty;
     /// Source location for this expression.
     cstc::span::SourceSpan span;
-    /// True when this expression is guaranteed not to depend on runtime input.
+    /// Legacy compatibility shim derived from `availability`.
     bool ct_available = true;
-    /// Body-internal runtime dependence that must be exposed by a result contract.
+    /// Legacy compatibility shim derived from `availability.evidence`.
     std::optional<TyRuntimeEvidence> runtime_evidence;
+    /// Canonical compile-time/runtime availability summary.
+    Availability availability;
 };
+
+/// Synchronizes the legacy expression availability shims from the canonical
+/// summary.
+inline void set_availability(TyExpr& expr, const Availability& availability) {
+    expr.availability = availability;
+    expr.ct_available = is_ct_available(expr.availability);
+    expr.runtime_evidence = expr.availability.evidence;
+}
+
+/// Recomputes canonical expression availability from the current type and
+/// legacy shims.
+inline void refresh_availability(TyExpr& expr) {
+    set_availability(
+        expr,
+        availability_from_legacy(expr.ty, expr.span, expr.ct_available, expr.runtime_evidence));
+}
+
+/// Returns true when an expression value is compile-time available.
+[[nodiscard]] inline bool is_ct_available(const TyExpr& expr) {
+    return is_ct_available(expr.availability);
+}
+
+/// Returns true when an expression pointer is non-null and compile-time
+/// available.
+[[nodiscard]] inline bool is_ct_available(const TyExprPtr& expr) {
+    return expr != nullptr && is_ct_available(*expr);
+}
 
 /// Constructs a heap-allocated typed expression.
 [[nodiscard]] inline TyExprPtr make_ty_expr(
     cstc::span::SourceSpan span, TyExpr::Node node, Ty ty, bool ct_available = true,
-    std::optional<TyRuntimeEvidence> runtime_evidence = std::nullopt) {
-    return std::make_shared<TyExpr>(
-        TyExpr{std::move(node), std::move(ty), span, ct_available, std::move(runtime_evidence)});
+    const std::optional<TyRuntimeEvidence>& runtime_evidence = std::nullopt) {
+    TyExpr expr;
+    expr.node = std::move(node);
+    expr.ty = std::move(ty);
+    expr.span = span;
+    set_availability(expr, availability_from_legacy(expr.ty, span, ct_available, runtime_evidence));
+    return std::make_shared<TyExpr>(std::move(expr));
 }
 
 // ─── Statements ──────────────────────────────────────────────────────────────
@@ -584,11 +705,38 @@ struct TyBlock {
     Ty ty;
     /// Source location for the full block.
     cstc::span::SourceSpan span;
-    /// True when the block's yielded value is guaranteed compile-time available.
+    /// Legacy compatibility shim derived from `availability`.
     bool ct_available = true;
-    /// Body-internal runtime dependence joined from reachable statements and tail.
+    /// Legacy compatibility shim derived from `availability.evidence`.
     std::optional<TyRuntimeEvidence> runtime_evidence;
+    /// Canonical compile-time/runtime availability summary.
+    Availability availability;
 };
+
+/// Synchronizes the legacy block availability shims from the canonical summary.
+inline void set_availability(TyBlock& block, const Availability& availability) {
+    block.availability = availability;
+    block.ct_available = is_ct_available(block.availability);
+    block.runtime_evidence = block.availability.evidence;
+}
+
+/// Recomputes canonical block availability from the current type and legacy
+/// shims.
+inline void refresh_availability(TyBlock& block) {
+    set_availability(
+        block,
+        availability_from_legacy(block.ty, block.span, block.ct_available, block.runtime_evidence));
+}
+
+/// Returns true when a block value is compile-time available.
+[[nodiscard]] inline bool is_ct_available(const TyBlock& block) {
+    return is_ct_available(block.availability);
+}
+
+/// Returns true when a block pointer is non-null and compile-time available.
+[[nodiscard]] inline bool is_ct_available(const TyBlockPtr& block) {
+    return block != nullptr && is_ct_available(*block);
+}
 
 /// Typed generic constraint attached to a generic declaration.
 struct TyGenericConstraint {

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -401,16 +401,6 @@ struct Availability {
     return ty_contains_runtime_tag(ty) ? availability_rt() : availability_ct();
 }
 
-/// Converts legacy split fields into the canonical availability summary.
-[[nodiscard]] inline Availability availability_from_legacy(
-    const Ty& ty, cstc::span::SourceSpan span, bool ct_available,
-    const std::optional<TyRuntimeEvidence>& runtime_evidence = std::nullopt) {
-    Availability availability = availability_from_type(ty, span);
-    if (!ct_available || runtime_evidence.has_value())
-        availability = availability_join(availability, availability_rt(runtime_evidence));
-    return availability;
-}
-
 /// Applies an availability summary to a type used for expression display or
 /// lowering decisions.
 [[nodiscard]] inline Ty with_availability_projection(Ty shape, const Availability& availability) {
@@ -612,28 +602,13 @@ struct TyExpr {
     Ty ty;
     /// Source location for this expression.
     cstc::span::SourceSpan span;
-    /// Legacy compatibility shim derived from `availability`.
-    bool ct_available = true;
-    /// Legacy compatibility shim derived from `availability.evidence`.
-    std::optional<TyRuntimeEvidence> runtime_evidence;
     /// Canonical compile-time/runtime availability summary.
     Availability availability;
 };
 
-/// Synchronizes the legacy expression availability shims from the canonical
-/// summary.
+/// Sets expression availability, preserving runtime-qualified type projections.
 inline void set_availability(TyExpr& expr, const Availability& availability) {
-    expr.availability = availability;
-    expr.ct_available = is_ct_available(expr.availability);
-    expr.runtime_evidence = expr.availability.evidence;
-}
-
-/// Recomputes canonical expression availability from the current type and
-/// legacy shims.
-inline void refresh_availability(TyExpr& expr) {
-    set_availability(
-        expr,
-        availability_from_legacy(expr.ty, expr.span, expr.ct_available, expr.runtime_evidence));
+    expr.availability = availability_join(availability_from_type(expr.ty, expr.span), availability);
 }
 
 /// Returns true when an expression value is compile-time available.
@@ -649,13 +624,13 @@ inline void refresh_availability(TyExpr& expr) {
 
 /// Constructs a heap-allocated typed expression.
 [[nodiscard]] inline TyExprPtr make_ty_expr(
-    cstc::span::SourceSpan span, TyExpr::Node node, Ty ty, bool ct_available = true,
-    const std::optional<TyRuntimeEvidence>& runtime_evidence = std::nullopt) {
+    cstc::span::SourceSpan span, TyExpr::Node node, Ty ty,
+    const Availability& availability = availability_ct()) {
     TyExpr expr;
     expr.node = std::move(node);
     expr.ty = std::move(ty);
     expr.span = span;
-    set_availability(expr, availability_from_legacy(expr.ty, span, ct_available, runtime_evidence));
+    set_availability(expr, availability);
     return std::make_shared<TyExpr>(std::move(expr));
 }
 
@@ -705,27 +680,14 @@ struct TyBlock {
     Ty ty;
     /// Source location for the full block.
     cstc::span::SourceSpan span;
-    /// Legacy compatibility shim derived from `availability`.
-    bool ct_available = true;
-    /// Legacy compatibility shim derived from `availability.evidence`.
-    std::optional<TyRuntimeEvidence> runtime_evidence;
     /// Canonical compile-time/runtime availability summary.
     Availability availability;
 };
 
-/// Synchronizes the legacy block availability shims from the canonical summary.
+/// Sets block availability, preserving runtime-qualified type projections.
 inline void set_availability(TyBlock& block, const Availability& availability) {
-    block.availability = availability;
-    block.ct_available = is_ct_available(block.availability);
-    block.runtime_evidence = block.availability.evidence;
-}
-
-/// Recomputes canonical block availability from the current type and legacy
-/// shims.
-inline void refresh_availability(TyBlock& block) {
-    set_availability(
-        block,
-        availability_from_legacy(block.ty, block.span, block.ct_available, block.runtime_evidence));
+    block.availability =
+        availability_join(availability_from_type(block.ty, block.span), availability);
 }
 
 /// Returns true when a block value is compile-time available.

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -608,7 +608,8 @@ struct TyExpr {
 
 /// Sets expression availability, preserving runtime-qualified type projections.
 inline void set_availability(TyExpr& expr, const Availability& availability) {
-    expr.availability = availability_join(availability_from_type(expr.ty, expr.span), availability);
+    expr.availability = availability;
+    expr.ty = with_availability_projection(std::move(expr.ty), expr.availability);
 }
 
 /// Returns true when an expression value is compile-time available.
@@ -630,7 +631,8 @@ inline void set_availability(TyExpr& expr, const Availability& availability) {
     expr.node = std::move(node);
     expr.ty = std::move(ty);
     expr.span = span;
-    set_availability(expr, availability);
+    set_availability(
+        expr, availability_join(availability_from_type(expr.ty, expr.span), availability));
     return std::make_shared<TyExpr>(std::move(expr));
 }
 
@@ -686,8 +688,8 @@ struct TyBlock {
 
 /// Sets block availability, preserving runtime-qualified type projections.
 inline void set_availability(TyBlock& block, const Availability& availability) {
-    block.availability =
-        availability_join(availability_from_type(block.ty, block.span), availability);
+    block.availability = availability;
+    block.ty = with_availability_projection(std::move(block.ty), block.availability);
 }
 
 /// Returns true when a block value is compile-time available.

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -417,8 +417,7 @@ struct Availability {
 }
 
 /// Projects a source/runtime-qualified type into an availability summary.
-[[nodiscard]] inline Availability
-    availability_from_type(const Ty& ty, [[maybe_unused]] cstc::span::SourceSpan span = {}) {
+[[nodiscard]] inline Availability availability_from_type(const Ty& ty) {
     return ty_contains_runtime_tag(ty) ? availability_rt() : availability_ct();
 }
 
@@ -658,8 +657,7 @@ inline void set_availability(TyExpr& expr, const Availability& availability) {
     expr.node = std::move(node);
     expr.ty = std::move(ty);
     expr.span = span;
-    set_availability(
-        expr, availability_join(availability_from_type(expr.ty, expr.span), availability));
+    set_availability(expr, availability_join(availability_from_type(expr.ty), availability));
     return std::make_shared<TyExpr>(std::move(expr));
 }
 

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -371,6 +371,9 @@ struct Availability {
     AvailabilityKind kind = AvailabilityKind::Ct;
     /// First concrete runtime contributor, when available.
     std::optional<TyRuntimeEvidence> evidence;
+    /// True when a CT-looking expression may depend on a runtime-allowed
+    /// declaration parameter under a non-CT call-site instantiation.
+    bool depends_on_runtime_allowed_param = false;
 };
 
 /// Compile-time-available summary.
@@ -379,19 +382,38 @@ struct Availability {
 /// Runtime-dependent summary, optionally carrying first-origin evidence.
 [[nodiscard]] inline Availability
     availability_rt(std::optional<TyRuntimeEvidence> evidence = std::nullopt) {
-    return Availability{AvailabilityKind::Rt, std::move(evidence)};
+    return Availability{AvailabilityKind::Rt, std::move(evidence), false};
+}
+
+/// Symbolic availability for an ordinary plain parameter inside a declaration.
+[[nodiscard]] inline Availability availability_runtime_allowed_param() {
+    return Availability{AvailabilityKind::Ct, std::nullopt, true};
 }
 
 /// Joins two availability summaries; runtime wins and the first concrete
 /// evidence is preserved.
 [[nodiscard]] inline Availability
     availability_join(const Availability& lhs, const Availability& rhs) {
-    if (lhs.kind == AvailabilityKind::Ct)
-        return rhs;
-    if (rhs.kind == AvailabilityKind::Ct)
-        return lhs;
+    if (lhs.kind == AvailabilityKind::Ct && rhs.kind == AvailabilityKind::Ct) {
+        return Availability{
+            AvailabilityKind::Ct, std::nullopt,
+            lhs.depends_on_runtime_allowed_param || rhs.depends_on_runtime_allowed_param};
+    }
+    if (lhs.kind == AvailabilityKind::Ct) {
+        Availability joined = rhs;
+        joined.depends_on_runtime_allowed_param =
+            lhs.depends_on_runtime_allowed_param || rhs.depends_on_runtime_allowed_param;
+        return joined;
+    }
+    if (rhs.kind == AvailabilityKind::Ct) {
+        Availability joined = lhs;
+        joined.depends_on_runtime_allowed_param =
+            lhs.depends_on_runtime_allowed_param || rhs.depends_on_runtime_allowed_param;
+        return joined;
+    }
     return Availability{
-        AvailabilityKind::Rt, lhs.evidence.has_value() ? lhs.evidence : rhs.evidence};
+        AvailabilityKind::Rt, lhs.evidence.has_value() ? lhs.evidence : rhs.evidence,
+        lhs.depends_on_runtime_allowed_param || rhs.depends_on_runtime_allowed_param};
 }
 
 /// Projects a source/runtime-qualified type into an availability summary.
@@ -413,6 +435,12 @@ struct Availability {
 /// Returns true when the canonical availability summary is compile-time.
 [[nodiscard]] inline bool is_ct_available(const Availability& availability) {
     return availability.kind == AvailabilityKind::Ct;
+}
+
+/// Returns true when an expression may satisfy a CT-required position.
+[[nodiscard]] inline bool is_ct_required_available(const Availability& availability) {
+    return availability.kind == AvailabilityKind::Ct
+        && !availability.depends_on_runtime_allowed_param;
 }
 
 /// Single named-field initializer inside a struct construction expression.

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -418,8 +418,7 @@ struct Availability {
 
 /// Projects a source/runtime-qualified type into an availability summary.
 [[nodiscard]] inline Availability
-    availability_from_type(const Ty& ty, cstc::span::SourceSpan span = {}) {
-    (void)span;
+    availability_from_type(const Ty& ty, [[maybe_unused]] cstc::span::SourceSpan span = {}) {
     return ty_contains_runtime_tag(ty) ? availability_rt() : availability_ct();
 }
 

--- a/compiler/cstc_tyir/include/cstc_tyir/type_compat.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/type_compat.hpp
@@ -19,17 +19,7 @@ namespace cstc::tyir {
 /// Returns true when `ty` or any nested type argument/pointee carries the
 /// `runtime` qualifier.
 [[nodiscard]] inline bool type_has_runtime_dependency(const Ty& ty) {
-    if (ty.is_runtime)
-        return true;
-    if (ty.kind == TyKind::Ref)
-        return ty.pointee != nullptr && type_has_runtime_dependency(*ty.pointee);
-    if (ty.kind != TyKind::Named)
-        return false;
-    for (const Ty& arg : ty.generic_args) {
-        if (type_has_runtime_dependency(arg))
-            return true;
-    }
-    return false;
+    return ty_contains_runtime_tag(ty);
 }
 
 /// Returns true when `actual` may appear where `expected` is required.

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -106,6 +106,18 @@ static void test_availability_join_preserves_first_evidence() {
     assert(joined.evidence->reason == "first");
 }
 
+static void test_runtime_allowed_param_availability_is_symbolic_ct() {
+    const Availability param = availability_runtime_allowed_param();
+    assert(is_ct_available(param));
+    assert(!is_ct_required_available(param));
+    assert(param.depends_on_runtime_allowed_param);
+
+    const Availability joined = availability_join(availability_ct(), param);
+    assert(is_ct_available(joined));
+    assert(!is_ct_required_available(joined));
+    assert(joined.depends_on_runtime_allowed_param);
+}
+
 static void test_availability_projection() {
     assert(with_availability_projection(ty::num(), availability_ct()) == ty::num());
     assert(with_availability_projection(ty::num(), availability_rt()) == ty::num(true));
@@ -238,6 +250,7 @@ int main() {
     test_runtime_ty();
     test_availability_from_type_detects_nested_runtime_tags();
     test_availability_join_preserves_first_evidence();
+    test_runtime_allowed_param_availability_is_symbolic_ct();
     test_availability_projection();
     test_set_availability_projects_type();
     test_named_shape_distinguishes_nominal_types();

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -70,6 +70,20 @@ static void test_runtime_ty() {
     assert(borrowed_runtime_handle != ty::ref(ty::named(handle)));
 }
 
+static void test_availability_from_type_detects_nested_runtime_tags() {
+    const Symbol box = Symbol::intern("Box");
+    const Ty plain_box = ty::named(box, kInvalidSymbol, ValueSemantics::Move, false, {ty::num()});
+    const Ty borrowed_runtime_box =
+        ty::ref(ty::named(box, kInvalidSymbol, ValueSemantics::Move, false, {ty::num(true)}));
+
+    assert(!ty_contains_runtime_tag(plain_box));
+    assert(ty_contains_runtime_tag(borrowed_runtime_box));
+
+    const Availability availability = availability_from_type(borrowed_runtime_box);
+    assert(availability.kind == AvailabilityKind::Rt);
+    assert(!availability.evidence.has_value());
+}
+
 static void test_availability_join_preserves_first_evidence() {
     const Availability ct = availability_ct();
     const Availability runtime_from_type = availability_from_type(ty::num(true));
@@ -222,6 +236,7 @@ int main() {
     test_ty_named();
     test_ty_named_with_generic_args();
     test_runtime_ty();
+    test_availability_from_type_detects_nested_runtime_tags();
     test_availability_join_preserves_first_evidence();
     test_availability_projection();
     test_set_availability_projects_type();

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -124,14 +124,13 @@ static void test_make_literal() {
     assert(is_ct_available(*expr));
 }
 
-static void test_make_runtime_expr_derives_legacy_shims() {
+static void test_make_runtime_expr_derives_availability() {
     const TyExprPtr expr = make_ty_expr(
         {}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern("1"), false}, ty::num(true));
     assert(expr != nullptr);
     assert(!is_ct_available(*expr));
-    assert(!expr->ct_available);
-    assert(!expr->runtime_evidence.has_value());
     assert(expr->availability.kind == AvailabilityKind::Rt);
+    assert(!expr->availability.evidence.has_value());
 }
 
 static void test_make_local_ref() {
@@ -208,7 +207,7 @@ int main() {
     test_named_shape_distinguishes_nominal_types();
     test_ty_equality_distinguishes_value_semantics();
     test_make_literal();
-    test_make_runtime_expr_derives_legacy_shims();
+    test_make_runtime_expr_derives_availability();
     test_make_local_ref();
     test_make_binary();
     test_empty_program();

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -98,6 +98,26 @@ static void test_availability_projection() {
     assert(with_availability_projection(ty::never(), availability_rt()) == ty::never());
 }
 
+static void test_set_availability_projects_type() {
+    const TyExprPtr expr = make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern("1"), false}, ty::num(),
+        availability_rt());
+    assert(expr->ty == ty::num(true));
+    assert(expr->availability.kind == AvailabilityKind::Rt);
+    set_availability(*expr, availability_ct());
+    assert(expr->ty == ty::num());
+    assert(expr->availability.kind == AvailabilityKind::Ct);
+
+    TyBlock block;
+    block.ty = ty::unit();
+    set_availability(block, availability_rt());
+    assert(block.ty == ty::unit(true));
+    assert(block.availability.kind == AvailabilityKind::Rt);
+    set_availability(block, availability_ct());
+    assert(block.ty == ty::unit());
+    assert(block.availability.kind == AvailabilityKind::Ct);
+}
+
 static void test_named_shape_distinguishes_nominal_types() {
     const Symbol point = Symbol::intern("Point");
     const Symbol color = Symbol::intern("Color");
@@ -204,6 +224,7 @@ int main() {
     test_runtime_ty();
     test_availability_join_preserves_first_evidence();
     test_availability_projection();
+    test_set_availability_projects_type();
     test_named_shape_distinguishes_nominal_types();
     test_ty_equality_distinguishes_value_semantics();
     test_make_literal();

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -104,6 +104,12 @@ static void test_availability_join_preserves_first_evidence() {
     assert(joined.evidence.has_value());
     assert(joined.evidence->span.start == 1);
     assert(joined.evidence->reason == "first");
+
+    const Availability joined_fallback =
+        availability_join(runtime_from_type, availability_rt(second));
+    assert(joined_fallback.evidence.has_value());
+    assert(joined_fallback.evidence->span.start == 3);
+    assert(joined_fallback.evidence->reason == "second");
 }
 
 static void test_runtime_allowed_param_availability_is_symbolic_ct() {

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -70,6 +70,34 @@ static void test_runtime_ty() {
     assert(borrowed_runtime_handle != ty::ref(ty::named(handle)));
 }
 
+static void test_availability_join_preserves_first_evidence() {
+    const Availability ct = availability_ct();
+    const Availability runtime_from_type = availability_from_type(ty::num(true));
+    assert(is_ct_available(ct));
+    assert(!is_ct_available(runtime_from_type));
+    assert(!runtime_from_type.evidence.has_value());
+
+    const TyRuntimeEvidence first{
+        {1, 2},
+        "first"
+    };
+    const TyRuntimeEvidence second{
+        {3, 4},
+        "second"
+    };
+    const Availability joined = availability_join(availability_rt(first), availability_rt(second));
+    assert(!is_ct_available(joined));
+    assert(joined.evidence.has_value());
+    assert(joined.evidence->span.start == 1);
+    assert(joined.evidence->reason == "first");
+}
+
+static void test_availability_projection() {
+    assert(with_availability_projection(ty::num(), availability_ct()) == ty::num());
+    assert(with_availability_projection(ty::num(), availability_rt()) == ty::num(true));
+    assert(with_availability_projection(ty::never(), availability_rt()) == ty::never());
+}
+
 static void test_named_shape_distinguishes_nominal_types() {
     const Symbol point = Symbol::intern("Point");
     const Symbol color = Symbol::intern("Color");
@@ -93,6 +121,17 @@ static void test_make_literal() {
     assert(expr->ty == ty::num());
     assert(std::holds_alternative<TyLiteral>(expr->node));
     assert(std::get<TyLiteral>(expr->node).kind == TyLiteral::Kind::Num);
+    assert(is_ct_available(*expr));
+}
+
+static void test_make_runtime_expr_derives_legacy_shims() {
+    const TyExprPtr expr = make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern("1"), false}, ty::num(true));
+    assert(expr != nullptr);
+    assert(!is_ct_available(*expr));
+    assert(!expr->ct_available);
+    assert(!expr->runtime_evidence.has_value());
+    assert(expr->availability.kind == AvailabilityKind::Rt);
 }
 
 static void test_make_local_ref() {
@@ -164,9 +203,12 @@ int main() {
     test_ty_named();
     test_ty_named_with_generic_args();
     test_runtime_ty();
+    test_availability_join_preserves_first_evidence();
+    test_availability_projection();
     test_named_shape_distinguishes_nominal_types();
     test_ty_equality_distinguishes_value_semantics();
     test_make_literal();
+    test_make_runtime_expr_derives_legacy_shims();
     test_make_local_ref();
     test_make_binary();
     test_empty_program();

--- a/compiler/cstc_tyir/tests/tyir_basic.cpp
+++ b/compiler/cstc_tyir/tests/tyir_basic.cpp
@@ -82,6 +82,10 @@ static void test_availability_from_type_detects_nested_runtime_tags() {
     const Availability availability = availability_from_type(borrowed_runtime_box);
     assert(availability.kind == AvailabilityKind::Rt);
     assert(!availability.evidence.has_value());
+
+    const Availability runtime_num = availability_from_type(ty::num(true));
+    assert(runtime_num.kind == AvailabilityKind::Rt);
+    assert(runtime_num.evidence == std::nullopt);
 }
 
 static void test_availability_join_preserves_first_evidence() {

--- a/compiler/cstc_tyir/tests/tyir_print.cpp
+++ b/compiler/cstc_tyir/tests/tyir_print.cpp
@@ -711,7 +711,7 @@ static void test_print_availability_summary() {
     prog.items.push_back(std::move(fn));
 
     const std::string out = format_program(prog);
-    assert(contains(out, "TyBlock: num [availability: runtime]"));
+    assert(contains(out, "TyBlock: runtime num [availability: runtime]"));
     assert(contains(out, "TyRuntimeBlock: runtime num [availability: runtime]"));
     assert(contains(out, "TyLiteral(3): num [availability: const]"));
 }

--- a/compiler/cstc_tyir/tests/tyir_print.cpp
+++ b/compiler/cstc_tyir/tests/tyir_print.cpp
@@ -685,6 +685,37 @@ static void test_print_runtime_block() {
     assert(contains(out, "TyLiteral(3): num"));
 }
 
+static void test_print_availability_summary() {
+    auto runtime_expr = make_ty_expr(
+        {
+    },
+        TyRuntimeBlock{std::make_shared<TyBlock>()}, ty::num(true), false,
+        TyRuntimeEvidence{{1, 2}, "runtime block"});
+    auto ct_expr =
+        make_ty_expr({}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern("3"), false}, ty::num());
+
+    auto block = std::make_shared<TyBlock>();
+    block->stmts = {
+        TyExprStmt{runtime_expr, {}}
+    };
+    block->tail = ct_expr;
+    block->ty = ty::num();
+    set_availability(*block, availability_rt(runtime_expr->availability.evidence));
+
+    TyFnDecl fn;
+    fn.name = Symbol::intern("availability");
+    fn.return_ty = ty::num();
+    fn.body = block;
+
+    TyProgram prog;
+    prog.items.push_back(std::move(fn));
+
+    const std::string out = format_program(prog);
+    assert(contains(out, "TyBlock: num [availability: RT]"));
+    assert(contains(out, "TyRuntimeBlock: runtime num [availability: RT]"));
+    assert(contains(out, "TyLiteral(3): num [availability: CT]"));
+}
+
 // ─── Let statement ───────────────────────────────────────────────────────────
 
 static void test_print_let_stmt() {
@@ -760,6 +791,7 @@ int main() {
     test_print_for();
     test_print_call();
     test_print_runtime_block();
+    test_print_availability_summary();
     test_print_let_stmt();
     test_print_discard_let();
 

--- a/compiler/cstc_tyir/tests/tyir_print.cpp
+++ b/compiler/cstc_tyir/tests/tyir_print.cpp
@@ -689,8 +689,8 @@ static void test_print_availability_summary() {
     auto runtime_expr = make_ty_expr(
         {
     },
-        TyRuntimeBlock{std::make_shared<TyBlock>()}, ty::num(true), false,
-        TyRuntimeEvidence{{1, 2}, "runtime block"});
+        TyRuntimeBlock{std::make_shared<TyBlock>()}, ty::num(true),
+        availability_rt(TyRuntimeEvidence{{1, 2}, "runtime block"}));
     auto ct_expr =
         make_ty_expr({}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern("3"), false}, ty::num());
 
@@ -711,9 +711,9 @@ static void test_print_availability_summary() {
     prog.items.push_back(std::move(fn));
 
     const std::string out = format_program(prog);
-    assert(contains(out, "TyBlock: num [availability: RT]"));
-    assert(contains(out, "TyRuntimeBlock: runtime num [availability: RT]"));
-    assert(contains(out, "TyLiteral(3): num [availability: CT]"));
+    assert(contains(out, "TyBlock: num [availability: runtime]"));
+    assert(contains(out, "TyRuntimeBlock: runtime num [availability: runtime]"));
+    assert(contains(out, "TyLiteral(3): num [availability: const]"));
 }
 
 // ─── Let statement ───────────────────────────────────────────────────────────

--- a/compiler/cstc_tyir_builder/README.md
+++ b/compiler/cstc_tyir_builder/README.md
@@ -75,6 +75,13 @@ Runtime block expressions use dedicated lowering: `runtime { ... }` becomes a
 result is promoted to `runtime T`, but pure inner expressions keep their normal
 types so later const-folding can still inspect them.
 
+Ordinary plain parameters are lowered as compile-time-shaped values with symbolic
+runtime-allowed dependence. The declaration body does not become runtime-qualified
+only because such a parameter is used; instead, call lowering instantiates the
+parameter with the actual argument availability and lifts the call result when a
+runtime-dependent argument is passed. CT-required parameters and `const` local
+annotations reject this symbolic dependence before residualization.
+
 ### Main function constraints
 
 The `main` function, if present, is restricted to return one of:

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -2409,7 +2409,7 @@ struct ParamReferenceVisitor {
 
 static void recompute_block_summary(tyir::TyBlock& block) {
     bool reachable = true;
-    tyir::Availability availability = tyir::availability_from_type(block.ty, block.span);
+    tyir::Availability availability = tyir::availability_ct();
 
     for (const tyir::TyStmt& stmt : block.stmts) {
         if (!reachable)
@@ -3805,8 +3805,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                + sig.return_ty.display() + "'");
 
     if (fn.is_runtime) {
-        body->ty.is_runtime = true;
-        recompute_block_summary(*body);
+        tyir::set_availability(
+            *body, tyir::availability_join(tyir::availability_rt(), body->availability));
     }
 
     auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -1891,9 +1891,11 @@ struct ParamReferenceVisitor {
                 return std::unexpected(std::move(joined_ty.error()));
             expr->ty = *joined_ty;
         }
-        tyir::Availability if_availability = tyir::availability_join(
-            if_expr->condition->availability, if_expr->then_block->availability);
-        if (if_expr->else_branch.has_value())
+        tyir::Availability if_availability = if_expr->condition->availability;
+        if (expr_can_fallthrough(*if_expr->condition))
+            if_availability =
+                tyir::availability_join(if_availability, if_expr->then_block->availability);
+        if (expr_can_fallthrough(*if_expr->condition) && if_expr->else_branch.has_value())
             if_availability =
                 tyir::availability_join(if_availability, (*if_expr->else_branch)->availability);
         if (if_availability.evidence.has_value()) {
@@ -3311,8 +3313,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 const bool then_reaches_join = block_can_fallthrough(*then_ptr);
 
                 tyir::Ty result_ty = then_ptr->ty;
-                tyir::Availability if_availability =
-                    tyir::availability_join(cond->expr->availability, then_ptr->availability);
+                const bool condition_reaches_branches = expr_can_fallthrough(*cond->expr);
+                tyir::Availability if_availability = cond->expr->availability;
+                if (condition_reaches_branches)
+                    if_availability =
+                        tyir::availability_join(if_availability, then_ptr->availability);
 
                 std::optional<tyir::TyExprPtr> else_branch;
                 if (node.else_branch.has_value()) {
@@ -3346,8 +3351,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     if (expr_can_fallthrough(*else_val->expr))
                         ctx.scope.merge_from(else_ctx.scope);
 
-                    if_availability =
-                        tyir::availability_join(if_availability, else_val->expr->availability);
+                    if (condition_reaches_branches)
+                        if_availability =
+                            tyir::availability_join(if_availability, else_val->expr->availability);
                     else_branch = std::move(else_val->expr);
                 } else {
                     // No else branch: result type is Unit
@@ -3439,8 +3445,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                const tyir::Availability while_availability =
-                    tyir::availability_join(cond->expr->availability, body_ptr->availability);
+                tyir::Availability while_availability = cond->expr->availability;
+                if (expr_can_fallthrough(*cond->expr))
+                    while_availability =
+                        tyir::availability_join(while_availability, body_ptr->availability);
                 tyir::Ty while_ty = tyir::ty::unit();
                 if (while_availability.evidence.has_value())
                     while_ty.is_runtime = true;

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -504,9 +504,9 @@ public:
             locals_.at(*borrowed_local).active_borrows += 1;
 
         const std::size_t index = locals_.size();
-        const tyir::Availability stored_availability =
-            tyir::availability_join(tyir::availability_from_type(ty), availability);
-        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local, stored_availability});
+        if (tyir::is_ct_available(availability))
+            ty = erase_runtime_qualifiers(ty);
+        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local, availability});
         frames_.back().bindings.emplace(name, index);
         return true;
     }

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -338,6 +338,16 @@ using TypeSubstitution =
     return tyir::is_ct_available(expr);
 }
 
+[[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
+
+[[nodiscard]] static bool exprs_can_fallthrough(const std::vector<tyir::TyExprPtr>& exprs) {
+    for (const tyir::TyExprPtr& expr : exprs) {
+        if (expr != nullptr && !expr_can_fallthrough(*expr))
+            return false;
+    }
+    return true;
+}
+
 [[nodiscard]] static bool
     call_argument_compatible(const tyir::Ty& actual, const tyir::Ty& expected) {
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
@@ -355,6 +365,8 @@ using TypeSubstitution =
 
 [[nodiscard]] static tyir::Ty
     lift_call_result_type(tyir::Ty result_ty, const std::vector<tyir::TyExprPtr>& args) {
+    if (!exprs_can_fallthrough(args))
+        return erase_runtime_qualifiers(result_ty);
     if (type_has_runtime_dependency(result_ty))
         result_ty.is_runtime = true;
     for (const tyir::TyExprPtr& arg : args) {
@@ -906,6 +918,8 @@ struct LowerCtx {
     call_result_type(tyir::Ty result_shape, const std::vector<tyir::TyExprPtr>& args) {
     if (result_shape.is_never())
         return result_shape;
+    if (!exprs_can_fallthrough(args))
+        return erase_runtime_qualifiers(result_shape);
     for (const tyir::TyExprPtr& arg : args) {
         if (arg != nullptr && type_has_runtime_dependency(arg->ty)) {
             result_shape.is_runtime = true;
@@ -1354,9 +1368,36 @@ struct LoweredExpr {
 [[nodiscard]] static tyir::Availability
     availability_from_exprs(const std::vector<tyir::TyExprPtr>& exprs) {
     tyir::Availability availability = tyir::availability_ct();
+    bool reachable = true;
     for (const tyir::TyExprPtr& expr : exprs) {
-        if (expr != nullptr)
-            availability = tyir::availability_join(availability, expr->availability);
+        if (expr == nullptr)
+            continue;
+        if (!reachable)
+            break;
+        availability = tyir::availability_join(availability, expr->availability);
+        reachable = expr_can_fallthrough(*expr);
+    }
+    return availability;
+}
+
+[[nodiscard]] static tyir::Availability availability_from_reached_call(
+    const std::vector<tyir::TyExprPtr>& args, cstc::span::SourceSpan span,
+    bool result_has_runtime_dependency) {
+    tyir::Availability availability = availability_from_exprs(args);
+    if (result_has_runtime_dependency && exprs_can_fallthrough(args)) {
+        availability = tyir::availability_join(
+            availability, runtime_availability_at(span, "runtime-result call"));
+    }
+    return availability;
+}
+
+[[nodiscard]] static tyir::Availability
+    availability_from_reached_binary(const tyir::TyExprPtr& lhs, const tyir::TyExprPtr& rhs) {
+    tyir::Availability availability = tyir::availability_ct();
+    if (lhs != nullptr) {
+        availability = tyir::availability_join(availability, lhs->availability);
+        if (expr_can_fallthrough(*lhs) && rhs != nullptr)
+            availability = tyir::availability_join(availability, rhs->availability);
     }
     return availability;
 }
@@ -1409,8 +1450,6 @@ struct LoweredPlace {
 
 [[nodiscard]] static std::expected<tyir::TyBlock, LowerError>
     lower_block(const ast::BlockExpr& block, LowerCtx& ctx);
-
-[[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
 
 [[nodiscard]] static bool block_can_fallthrough(const tyir::TyBlock& block);
 
@@ -1905,11 +1944,8 @@ struct ParamReferenceVisitor {
     const tyir::Ty resolved_return_shape =
         annotate_type_semantics(apply_substitution(sig.return_ty, substitution), ctx.env);
     const tyir::Ty resolved_return_ty = call_result_type(resolved_return_shape, deferred->args);
-    tyir::Availability deferred_call_availability = availability_from_exprs(deferred->args);
-    if (type_has_runtime_dependency(resolved_return_shape)) {
-        deferred_call_availability = tyir::availability_join(
-            deferred_call_availability, runtime_availability_at(expr->span, "runtime-result call"));
-    }
+    tyir::Availability deferred_call_availability = availability_from_reached_call(
+        deferred->args, expr->span, type_has_runtime_dependency(resolved_return_shape));
     if (!fully_resolved) {
         return tyir::make_ty_expr(
             expr->span,
@@ -1947,11 +1983,8 @@ struct ParamReferenceVisitor {
     }
 
     const tyir::Ty lifted_return_ty = lift_call_result_type(resolved_return_ty, resolved_args);
-    tyir::Availability call_availability = availability_from_exprs(resolved_args);
-    if (type_has_runtime_dependency(resolved_return_shape)) {
-        call_availability = tyir::availability_join(
-            call_availability, runtime_availability_at(expr->span, "runtime-result call"));
-    }
+    tyir::Availability call_availability = availability_from_reached_call(
+        resolved_args, expr->span, type_has_runtime_dependency(resolved_return_shape));
 
     return tyir::make_ty_expr(
         expr->span,
@@ -2749,6 +2782,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 seen_fields.reserve(node.fields.size());
                 tyir::Availability fields_availability = tyir::availability_ct();
                 bool fields_have_runtime_dependency = false;
+                bool fields_reachable = true;
 
                 for (const ast::StructInitField& field : node.fields) {
                     auto expected_ty = ctx.env.field_ty(type_name, field.name);
@@ -2782,10 +2816,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                             + "', found '" + val->expr->ty.display() + "'");
 
                     append_temp_borrows(temp_borrows, std::move(val->temp_borrows));
-                    fields_availability =
-                        tyir::availability_join(fields_availability, val->expr->availability);
-                    fields_have_runtime_dependency = fields_have_runtime_dependency
-                                                  || type_has_runtime_dependency(val->expr->ty);
+                    if (fields_reachable) {
+                        fields_availability =
+                            tyir::availability_join(fields_availability, val->expr->availability);
+                        fields_have_runtime_dependency |=
+                            type_has_runtime_dependency(val->expr->ty);
+                        fields_reachable = expr_can_fallthrough(*val->expr);
+                    }
 
                     lowered_fields.push_back(
                         tyir::TyStructInitField{field.name, std::move(val->expr), field.span});
@@ -2990,7 +3027,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     break;
                 }
                 const tyir::Availability binary_availability =
-                    tyir::availability_join(lhs->expr->availability, rhs->expr->availability);
+                    availability_from_reached_binary(lhs->expr, rhs->expr);
                 auto lowered = LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
@@ -3180,12 +3217,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
-                    tyir::Availability call_availability = availability_from_exprs(lowered_args);
-                    if (type_has_runtime_dependency(resolved_return_shape)) {
-                        call_availability = tyir::availability_join(
-                            call_availability,
-                            runtime_availability_at(expr->span, "runtime-result call"));
-                    }
+                    tyir::Availability call_availability = availability_from_reached_call(
+                        lowered_args, expr->span,
+                        type_has_runtime_dependency(resolved_return_shape));
 
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
@@ -3195,12 +3229,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 } else {
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
-                    tyir::Availability call_availability = availability_from_exprs(lowered_args);
-                    if (type_has_runtime_dependency(resolved_return_shape)) {
-                        call_availability = tyir::availability_join(
-                            call_availability,
-                            runtime_availability_at(expr->span, "runtime-result call"));
-                    }
+                    tyir::Availability call_availability = availability_from_reached_call(
+                        lowered_args, expr->span,
+                        type_has_runtime_dependency(resolved_return_shape));
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyDeferredGenericCall{

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -109,14 +109,24 @@ struct TypeEnv {
     /// `std::nullopt` if the field does not exist.
     [[nodiscard]] std::optional<tyir::Ty>
         field_ty(cstc::symbol::Symbol struct_name, cstc::symbol::Symbol field_name) const {
+        const tyir::TyFieldDecl* field = field_decl(struct_name, field_name);
+        if (field == nullptr)
+            return std::nullopt;
+        return field->ty;
+    }
+
+    /// Returns the resolved declaration of `field_name` on struct `struct_name`,
+    /// or `nullptr` if the field does not exist.
+    [[nodiscard]] const tyir::TyFieldDecl*
+        field_decl(cstc::symbol::Symbol struct_name, cstc::symbol::Symbol field_name) const {
         const auto it = struct_fields.find(struct_name);
         if (it == struct_fields.end())
-            return std::nullopt;
+            return nullptr;
         for (const tyir::TyFieldDecl& f : it->second) {
             if (f.name == field_name)
-                return f.ty;
+                return &f;
         }
-        return std::nullopt;
+        return nullptr;
     }
 
     /// Returns true when `variant_name` is a declared variant of `enum_name`.
@@ -2594,11 +2604,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         "field access on non-struct type '" + base->expr->ty.display() + "'");
 
-                auto field_ty = ctx.env.field_ty(base->expr->ty.name, node.field);
-                if (!field_ty)
+                const tyir::TyFieldDecl* field_decl = ctx.env.field_decl(base->expr->ty.name, node.field);
+                if (field_decl == nullptr)
                     return make_error(
                         expr->span, "no field '" + std::string(node.field.as_str())
                                         + "' in struct '" + base->expr->ty.display() + "'");
+                auto field_ty = field_decl->ty;
                 if (!base->expr->ty.generic_args.empty()) {
                     const auto generic_params_it =
                         ctx.env.type_generic_params.find(base->expr->ty.name);
@@ -2608,13 +2619,19 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         base->expr->ty.name.as_str());
                     if (!subst)
                         return std::unexpected(std::move(subst.error()));
-                    field_ty =
-                        annotate_type_semantics(apply_substitution(*field_ty, *subst), ctx.env);
+                    field_ty = annotate_type_semantics(apply_substitution(field_ty, *subst), ctx.env);
                 }
                 tyir::Ty lowered_field_ty =
-                    propagate_runtime_tag(*field_ty, base->expr->ty.is_runtime);
-                const tyir::Availability field_availability = tyir::availability_join(
-                    base->expr->availability, tyir::availability_from_type(lowered_field_ty));
+                    propagate_runtime_tag(field_ty, base->expr->ty.is_runtime);
+                tyir::Availability field_type_availability =
+                    tyir::availability_from_type(lowered_field_ty);
+                if (tyir::ty_contains_runtime_tag(field_ty)) {
+                    field_type_availability = runtime_availability_at(
+                        field_decl->span,
+                        "runtime field '" + std::string(node.field.as_str()) + "'");
+                }
+                const tyir::Availability field_availability =
+                    tyir::availability_join(base->expr->availability, field_type_availability);
 
                 return LoweredPlace{
                     tyir::make_ty_expr(

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -335,11 +335,11 @@ using TypeSubstitution =
 }
 
 [[nodiscard]] static bool value_is_ct_available(const bool ct_available, const tyir::Ty& ty) {
-    return ct_available && !type_has_runtime_dependency(ty);
+    return tyir::is_ct_available(tyir::availability_from_legacy(ty, {}, ct_available));
 }
 
 [[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
-    return expr != nullptr && value_is_ct_available(expr->ct_available, expr->ty);
+    return tyir::is_ct_available(expr);
 }
 
 [[nodiscard]] static bool all_exprs_ct_available(const std::vector<tyir::TyExprPtr>& exprs) {
@@ -1375,8 +1375,8 @@ struct LoweredExpr {
 [[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
     first_runtime_evidence(const std::vector<tyir::TyExprPtr>& exprs) {
     for (const tyir::TyExprPtr& expr : exprs) {
-        if (expr != nullptr && expr->runtime_evidence.has_value())
-            return expr->runtime_evidence;
+        if (expr != nullptr && expr->availability.evidence.has_value())
+            return expr->availability.evidence;
     }
     return std::nullopt;
 }
@@ -1387,9 +1387,9 @@ struct LoweredExpr {
         [](const auto& s) -> std::optional<tyir::TyRuntimeEvidence> {
             using S = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
-                return s.init != nullptr ? s.init->runtime_evidence : std::nullopt;
+                return s.init != nullptr ? s.init->availability.evidence : std::nullopt;
             else
-                return s.expr != nullptr ? s.expr->runtime_evidence : std::nullopt;
+                return s.expr != nullptr ? s.expr->availability.evidence : std::nullopt;
         },
         stmt);
 }
@@ -1426,11 +1426,9 @@ struct LoweredExpr {
 }
 
 static void apply_block_runtime_evidence(tyir::TyBlock& block) {
-    if (!block.runtime_evidence.has_value())
-        return;
-    block.ct_available = false;
-    if (!block.ty.is_never())
+    if (block.runtime_evidence.has_value() && !block.ty.is_never())
         block.ty.is_runtime = true;
+    tyir::refresh_availability(block);
 }
 
 struct LoweredPlace {
@@ -1836,8 +1834,7 @@ struct ParamReferenceVisitor {
                 block_can_fallthrough(**block) ? (*(*block)->tail)->ty : tyir::ty::never();
             recompute_block_summary(**block);
             expr->ty = (*block)->ty;
-            expr->ct_available = (*block)->ct_available;
-            expr->runtime_evidence = (*block)->runtime_evidence;
+            tyir::set_availability(*expr, (*block)->availability);
         }
         return expr;
     }
@@ -1860,8 +1857,8 @@ struct ParamReferenceVisitor {
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
-        expr->ct_available = false;
-        expr->runtime_evidence = runtime_evidence_at(expr->span, "runtime block");
+        tyir::set_availability(
+            *expr, tyir::availability_rt(runtime_evidence_at(expr->span, "runtime block")));
         return expr;
     }
 
@@ -1897,20 +1894,23 @@ struct ParamReferenceVisitor {
         const bool else_ct_available = if_expr->else_branch.has_value()
                                          ? expr_value_is_ct_available(*if_expr->else_branch)
                                          : true;
-        expr->runtime_evidence = first_runtime_evidence(
+        const auto if_runtime_evidence = first_runtime_evidence(
             first_runtime_evidence(
                 if_expr->condition->runtime_evidence, if_expr->then_block->runtime_evidence),
             if_expr->else_branch.has_value() ? (*if_expr->else_branch)->runtime_evidence
                                              : std::nullopt);
-        expr->ct_available = value_is_ct_available(
+        bool if_ct_available = value_is_ct_available(
             expr_value_is_ct_available(if_expr->condition) && if_expr->then_block->ct_available
                 && else_ct_available,
             expr->ty);
-        if (expr->runtime_evidence.has_value()) {
-            expr->ct_available = false;
+        if (if_runtime_evidence.has_value()) {
+            if_ct_available = false;
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
+        tyir::set_availability(
+            *expr, tyir::availability_from_legacy(
+                       expr->ty, expr->span, if_ct_available, if_runtime_evidence));
         return expr;
     }
 
@@ -2481,7 +2481,9 @@ static void recompute_block_summary(tyir::TyBlock& block) {
             first_runtime_evidence(block.runtime_evidence, (*block.tail)->runtime_evidence);
     }
 
-    block.ct_available = value_is_ct_available(ct_available, block.ty);
+    tyir::set_availability(
+        block,
+        tyir::availability_from_legacy(block.ty, block.span, ct_available, block.runtime_evidence));
     apply_block_runtime_evidence(block);
 }
 
@@ -3818,10 +3820,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
         },
         expr->node);
     if (lowered.has_value()) {
-        lowered->expr->ct_available =
-            value_is_ct_available(lowered->expr->ct_available, lowered->expr->ty);
-        if (lowered->expr->runtime_evidence.has_value())
-            lowered->expr->ct_available = false;
+        tyir::refresh_availability(*lowered->expr);
         lowered->deferred_generic_probe_validation = ctx.defer_generic_probe_validation;
     }
     return lowered;

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -2578,7 +2578,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 tyir::Ty lowered_field_ty =
                     propagate_runtime_tag(*field_ty, base->expr->ty.is_runtime);
-                const tyir::Availability field_availability = base->expr->availability;
+                const tyir::Availability field_availability = tyir::availability_join(
+                    base->expr->availability, tyir::availability_from_type(lowered_field_ty));
 
                 return LoweredPlace{
                     tyir::make_ty_expr(

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -3430,6 +3430,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 std::optional<tyir::TyForInit> lowered_init;
                 tyir::Availability for_availability = tyir::availability_ct();
+                bool for_segment_reachable = true;
 
                 if (node.init.has_value()) {
                     const auto& init_var = *node.init;
@@ -3500,8 +3501,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                                     + std::string(init_let->name.as_str()) + "'");
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
-                        for_availability = tyir::availability_join(
-                            for_availability, init_expr->expr->availability);
+                        if (for_segment_reachable) {
+                            for_availability = tyir::availability_join(
+                                for_availability, init_expr->expr->availability);
+                            for_segment_reachable = expr_can_fallthrough(*init_expr->expr);
+                        }
                         lowered_init = tyir::TyForInit{
                             init_let->discard, init_let->name, init_ty, std::move(init_expr->expr),
                             init_let->span};
@@ -3514,8 +3518,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             return std::unexpected(std::move(init_expr.error()));
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
-                        for_availability = tyir::availability_join(
-                            for_availability, init_expr->expr->availability);
+                        if (for_segment_reachable) {
+                            for_availability = tyir::availability_join(
+                                for_availability, init_expr->expr->availability);
+                            for_segment_reachable = expr_can_fallthrough(*init_expr->expr);
+                        }
                         // Treat as a discard init — wrap in TyForInit with discard=true
                         lowered_init = tyir::TyForInit{
                             true, cstc::symbol::kInvalidSymbol, init_expr->expr->ty,
@@ -3540,8 +3547,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 + cond->expr->ty.display() + "'");
                     }
                     release_temp_borrows(ctx, cond->temp_borrows);
-                    for_availability =
-                        tyir::availability_join(for_availability, cond->expr->availability);
+                    if (for_segment_reachable) {
+                        for_availability =
+                            tyir::availability_join(for_availability, cond->expr->availability);
+                        for_segment_reachable = expr_can_fallthrough(*cond->expr);
+                    }
                     lowered_cond = std::move(cond->expr);
                 }
 
@@ -3556,8 +3566,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 loop_ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                for_availability =
-                    tyir::availability_join(for_availability, body_ptr->availability);
+                const bool for_body_reachable = for_segment_reachable;
+                if (for_body_reachable)
+                    for_availability =
+                        tyir::availability_join(for_availability, body_ptr->availability);
 
                 std::optional<tyir::TyExprPtr> lowered_step;
                 if (node.step.has_value()) {
@@ -3567,8 +3579,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(step.error()));
                     }
                     release_temp_borrows(loop_ctx, step->temp_borrows);
-                    for_availability =
-                        tyir::availability_join(for_availability, step->expr->availability);
+                    if (for_body_reachable && block_can_fallthrough(*body_ptr))
+                        for_availability =
+                            tyir::availability_join(for_availability, step->expr->availability);
                     lowered_step = std::move(step->expr);
                 }
 

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -334,20 +334,8 @@ using TypeSubstitution =
     return erased;
 }
 
-[[nodiscard]] static bool value_is_ct_available(const bool ct_available, const tyir::Ty& ty) {
-    return tyir::is_ct_available(tyir::availability_from_legacy(ty, {}, ct_available));
-}
-
 [[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
     return tyir::is_ct_available(expr);
-}
-
-[[nodiscard]] static bool all_exprs_ct_available(const std::vector<tyir::TyExprPtr>& exprs) {
-    for (const tyir::TyExprPtr& expr : exprs) {
-        if (!expr_value_is_ct_available(expr))
-            return false;
-    }
-    return true;
 }
 
 [[nodiscard]] static bool
@@ -486,8 +474,7 @@ public:
         bool moved = false;
         std::size_t active_borrows = 0;
         std::optional<std::size_t> borrowed_local;
-        bool ct_available = true;
-        std::optional<tyir::TyRuntimeEvidence> runtime_evidence;
+        tyir::Availability availability;
     };
 
     void push() { frames_.push_back(Frame{{}, locals_.size()}); }
@@ -507,8 +494,8 @@ public:
 
     [[nodiscard]] bool insert(
         cstc::symbol::Symbol name, tyir::Ty ty,
-        std::optional<std::size_t> borrowed_local = std::nullopt, bool ct_available = true,
-        std::optional<tyir::TyRuntimeEvidence> runtime_evidence = std::nullopt) {
+        std::optional<std::size_t> borrowed_local = std::nullopt,
+        const tyir::Availability& availability = tyir::availability_ct()) {
         assert(!frames_.empty());
         if (frames_.back().bindings.contains(name))
             return false;
@@ -517,11 +504,9 @@ public:
             locals_.at(*borrowed_local).active_borrows += 1;
 
         const std::size_t index = locals_.size();
-        const bool stored_ct_available = value_is_ct_available(ct_available, ty);
-        locals_.push_back(
-            LocalState{
-                std::move(ty), false, 0, borrowed_local, stored_ct_available,
-                std::move(runtime_evidence)});
+        const tyir::Availability stored_availability =
+            tyir::availability_join(tyir::availability_from_type(ty), availability);
+        locals_.push_back(LocalState{std::move(ty), false, 0, borrowed_local, stored_availability});
         frames_.back().bindings.emplace(name, index);
         return true;
     }
@@ -552,7 +537,8 @@ public:
             locals_[i].moved = locals_[i].moved || other.locals_[i].moved;
             locals_[i].active_borrows =
                 std::max(locals_[i].active_borrows, other.locals_[i].active_borrows);
-            locals_[i].ct_available = locals_[i].ct_available && other.locals_[i].ct_available;
+            locals_[i].availability =
+                tyir::availability_join(locals_[i].availability, other.locals_[i].availability);
         }
     }
 
@@ -578,8 +564,8 @@ struct LoopCtx {
     /// yet; once a `break` is encountered the type is set (bare `break` → Unit,
     /// `break expr` → expr type).  Subsequent breaks must unify.
     std::optional<tyir::Ty> break_ty;
-    /// Compile-time availability of accumulated break values.
-    std::optional<bool> break_ct_available;
+    /// Availability of accumulated break values.
+    std::optional<tyir::Availability> break_availability;
 };
 
 // ─── Lowering context ────────────────────────────────────────────────────────
@@ -1364,71 +1350,51 @@ struct LoweredExpr {
     return tyir::TyRuntimeEvidence{span, std::move(reason)};
 }
 
-[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence> first_runtime_evidence(
-    const std::optional<tyir::TyRuntimeEvidence>& lhs,
-    const std::optional<tyir::TyRuntimeEvidence>& rhs) {
-    if (lhs.has_value())
-        return lhs;
-    return rhs;
+[[nodiscard]] static tyir::Availability
+    runtime_availability_at(cstc::span::SourceSpan span, std::string reason) {
+    return tyir::availability_rt(runtime_evidence_at(span, std::move(reason)));
 }
 
-[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
-    first_runtime_evidence(const std::vector<tyir::TyExprPtr>& exprs) {
+[[nodiscard]] static tyir::Availability
+    availability_from_exprs(const std::vector<tyir::TyExprPtr>& exprs) {
+    tyir::Availability availability = tyir::availability_ct();
     for (const tyir::TyExprPtr& expr : exprs) {
-        if (expr != nullptr && expr->availability.evidence.has_value())
-            return expr->availability.evidence;
+        if (expr != nullptr)
+            availability = tyir::availability_join(availability, expr->availability);
     }
-    return std::nullopt;
+    return availability;
 }
 
-[[nodiscard]] static std::optional<tyir::TyRuntimeEvidence>
-    stmt_runtime_evidence(const tyir::TyStmt& stmt) {
-    return std::visit(
-        [](const auto& s) -> std::optional<tyir::TyRuntimeEvidence> {
-            using S = std::decay_t<decltype(s)>;
-            if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
-                return s.init != nullptr ? s.init->availability.evidence : std::nullopt;
-            else
-                return s.expr != nullptr ? s.expr->availability.evidence : std::nullopt;
-        },
-        stmt);
-}
-
-[[nodiscard]] static bool stmt_value_is_ct_available(const tyir::TyStmt& stmt) {
-    auto expr_stmt_value_is_ct_available = [](const tyir::TyExprPtr& expr) {
+[[nodiscard]] static tyir::Availability stmt_availability(const tyir::TyStmt& stmt) {
+    auto expr_stmt_availability = [](const tyir::TyExprPtr& expr) {
         if (expr == nullptr)
-            return false;
-
-        auto payload_is_ct_available = [](const std::optional<tyir::TyExprPtr>& value) {
-            return !value.has_value() || expr_value_is_ct_available(*value);
-        };
+            return tyir::availability_ct();
 
         return std::visit(
             [&](const auto& node) {
                 using N = std::decay_t<decltype(node)>;
-                if constexpr (std::is_same_v<N, tyir::TyBreak> || std::is_same_v<N, tyir::TyReturn>)
-                    return payload_is_ct_available(node.value);
-                else
-                    return expr_value_is_ct_available(expr);
+                if constexpr (
+                    std::is_same_v<N, tyir::TyBreak> || std::is_same_v<N, tyir::TyReturn>) {
+                    return node.value.has_value()
+                             ? tyir::availability_join(
+                                   expr->availability, (*node.value)->availability)
+                             : expr->availability;
+                } else {
+                    return expr->availability;
+                }
             },
             expr->node);
     };
 
     return std::visit(
-        [&](const auto& s) {
+        [&](const auto& s) -> tyir::Availability {
             using S = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<S, tyir::TyLetStmt>)
-                return expr_value_is_ct_available(s.init);
+                return s.init != nullptr ? s.init->availability : tyir::availability_ct();
             else
-                return expr_stmt_value_is_ct_available(s.expr);
+                return expr_stmt_availability(s.expr);
         },
         stmt);
-}
-
-static void apply_block_runtime_evidence(tyir::TyBlock& block) {
-    if (block.runtime_evidence.has_value() && !block.ty.is_never())
-        block.ty.is_runtime = true;
-    tyir::refresh_availability(block);
 }
 
 struct LoweredPlace {
@@ -1857,8 +1823,7 @@ struct ParamReferenceVisitor {
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
-        tyir::set_availability(
-            *expr, tyir::availability_rt(runtime_evidence_at(expr->span, "runtime block")));
+        tyir::set_availability(*expr, runtime_availability_at(expr->span, "runtime block"));
         return expr;
     }
 
@@ -1891,26 +1856,16 @@ struct ParamReferenceVisitor {
                 return std::unexpected(std::move(joined_ty.error()));
             expr->ty = *joined_ty;
         }
-        const bool else_ct_available = if_expr->else_branch.has_value()
-                                         ? expr_value_is_ct_available(*if_expr->else_branch)
-                                         : true;
-        const auto if_runtime_evidence = first_runtime_evidence(
-            first_runtime_evidence(
-                if_expr->condition->runtime_evidence, if_expr->then_block->runtime_evidence),
-            if_expr->else_branch.has_value() ? (*if_expr->else_branch)->runtime_evidence
-                                             : std::nullopt);
-        bool if_ct_available = value_is_ct_available(
-            expr_value_is_ct_available(if_expr->condition) && if_expr->then_block->ct_available
-                && else_ct_available,
-            expr->ty);
-        if (if_runtime_evidence.has_value()) {
-            if_ct_available = false;
+        tyir::Availability if_availability = tyir::availability_join(
+            if_expr->condition->availability, if_expr->then_block->availability);
+        if (if_expr->else_branch.has_value())
+            if_availability =
+                tyir::availability_join(if_availability, (*if_expr->else_branch)->availability);
+        if (if_availability.evidence.has_value()) {
             if (!expr->ty.is_never())
                 expr->ty.is_runtime = true;
         }
-        tyir::set_availability(
-            *expr, tyir::availability_from_legacy(
-                       expr->ty, expr->span, if_ct_available, if_runtime_evidence));
+        tyir::set_availability(*expr, if_availability);
         return expr;
     }
 
@@ -1954,18 +1909,16 @@ struct ParamReferenceVisitor {
     const tyir::Ty resolved_return_shape =
         annotate_type_semantics(apply_substitution(sig.return_ty, substitution), ctx.env);
     const tyir::Ty resolved_return_ty = call_result_type(resolved_return_shape, deferred->args);
-    const bool deferred_call_ct_available =
-        value_is_ct_available(all_exprs_ct_available(deferred->args), resolved_return_ty);
-    const auto deferred_runtime_evidence = first_runtime_evidence(
-        first_runtime_evidence(deferred->args),
-        type_has_runtime_dependency(resolved_return_shape)
-            ? runtime_evidence_at(expr->span, "runtime-result call")
-            : std::nullopt);
+    tyir::Availability deferred_call_availability = availability_from_exprs(deferred->args);
+    if (type_has_runtime_dependency(resolved_return_shape)) {
+        deferred_call_availability = tyir::availability_join(
+            deferred_call_availability, runtime_availability_at(expr->span, "runtime-result call"));
+    }
     if (!fully_resolved) {
         return tyir::make_ty_expr(
             expr->span,
             tyir::TyDeferredGenericCall{deferred->fn_name, std::move(generic_args), deferred->args},
-            resolved_return_ty, deferred_call_ct_available, deferred_runtime_evidence);
+            resolved_return_ty, deferred_call_availability);
     }
 
     std::vector<tyir::Ty> concrete_generic_args;
@@ -1998,18 +1951,16 @@ struct ParamReferenceVisitor {
     }
 
     const tyir::Ty lifted_return_ty = lift_call_result_type(resolved_return_ty, resolved_args);
-    const bool call_ct_available =
-        value_is_ct_available(all_exprs_ct_available(resolved_args), lifted_return_ty);
-    const auto call_runtime_evidence = first_runtime_evidence(
-        first_runtime_evidence(resolved_args),
-        type_has_runtime_dependency(resolved_return_shape)
-            ? runtime_evidence_at(expr->span, "runtime-result call")
-            : std::nullopt);
+    tyir::Availability call_availability = availability_from_exprs(resolved_args);
+    if (type_has_runtime_dependency(resolved_return_shape)) {
+        call_availability = tyir::availability_join(
+            call_availability, runtime_availability_at(expr->span, "runtime-result call"));
+    }
 
     return tyir::make_ty_expr(
         expr->span,
         tyir::TyCall{deferred->fn_name, std::move(concrete_generic_args), std::move(resolved_args)},
-        lifted_return_ty, call_ct_available, call_runtime_evidence);
+        lifted_return_ty, call_availability);
 }
 
 [[nodiscard]] static std::expected<cstc::symbol::Symbol, LowerError>
@@ -2078,8 +2029,7 @@ struct ParamReferenceVisitor {
         return std::unexpected(std::move(constraint_fn.error()));
 
     return tyir::make_ty_expr(
-        expr->span, tyir::TyCall{*constraint_fn, {}, {expr}}, *constraint_ty,
-        expr_value_is_ct_available(expr));
+        expr->span, tyir::TyCall{*constraint_fn, {}, {expr}}, *constraint_ty, expr->availability);
 }
 
 [[nodiscard]] static std::expected<std::vector<tyir::TyGenericConstraint>, LowerError>
@@ -2114,7 +2064,9 @@ struct ParamReferenceVisitor {
         }
 
         for (const tyir::TyParam& param : *params) {
-            if (!ctx.scope.insert(param.name, param.ty, std::nullopt, param.requires_ct())) {
+            const tyir::Availability param_availability =
+                param.requires_ct() ? tyir::availability_ct() : tyir::availability_rt();
+            if (!ctx.scope.insert(param.name, param.ty, std::nullopt, param_availability)) {
                 ctx.scope.pop();
                 return make_error(
                     param.span, "duplicate parameter '" + std::string(param.name.as_str()) + "'");
@@ -2292,7 +2244,6 @@ struct ParamReferenceVisitor {
 
                 // Resolve binding type (explicit annotation or infer from init)
                 tyir::Ty binding_ty;
-                bool binding_ct_available = true;
                 if (s.type_annotation.has_value()) {
                     auto ann = lower_type(*s.type_annotation, ctx.env, s.span, ctx.generic_params);
                     if (!ann)
@@ -2320,7 +2271,6 @@ struct ParamReferenceVisitor {
                     if (!ct_check)
                         return std::unexpected(std::move(ct_check.error()));
                     binding_ty = *ann;
-                    binding_ct_available = expr_value_is_ct_available(init->expr);
                 } else {
                     if (auto unresolved = find_unresolved_deferred_generic_call(
                             init->expr, ctx.env, ctx.generic_params);
@@ -2330,7 +2280,6 @@ struct ParamReferenceVisitor {
                                         + std::string(unresolved->as_str()) + "'");
                     }
                     binding_ty = init->expr->ty;
-                    binding_ct_available = expr_value_is_ct_available(init->expr);
                 }
 
                 // Register binding in scope (unless discard pattern)
@@ -2348,8 +2297,7 @@ struct ParamReferenceVisitor {
                 }
                 if (!s.discard && s.name.is_valid()
                     && !ctx.scope.insert(
-                        s.name, binding_ty, borrowed_local, binding_ct_available,
-                        init->expr->runtime_evidence))
+                        s.name, binding_ty, borrowed_local, init->expr->availability))
                     return make_error(
                         s.span, "duplicate local binding '" + std::string(s.name.as_str()) + "'");
 
@@ -2462,29 +2410,23 @@ struct ParamReferenceVisitor {
 
 static void recompute_block_summary(tyir::TyBlock& block) {
     bool reachable = true;
-    bool ct_available = true;
-    block.runtime_evidence = std::nullopt;
+    tyir::Availability availability = tyir::availability_from_type(block.ty, block.span);
 
     for (const tyir::TyStmt& stmt : block.stmts) {
         if (!reachable)
             break;
 
-        ct_available = ct_available && stmt_value_is_ct_available(stmt);
-        block.runtime_evidence =
-            first_runtime_evidence(block.runtime_evidence, stmt_runtime_evidence(stmt));
+        availability = tyir::availability_join(availability, stmt_availability(stmt));
         reachable = stmt_can_fallthrough(stmt);
     }
 
     if (reachable && block.tail.has_value()) {
-        ct_available = ct_available && expr_value_is_ct_available(*block.tail);
-        block.runtime_evidence =
-            first_runtime_evidence(block.runtime_evidence, (*block.tail)->runtime_evidence);
+        availability = tyir::availability_join(availability, (*block.tail)->availability);
     }
 
-    tyir::set_availability(
-        block,
-        tyir::availability_from_legacy(block.ty, block.span, ct_available, block.runtime_evidence));
-    apply_block_runtime_evidence(block);
+    if (availability.evidence.has_value() && !block.ty.is_never())
+        block.ty.is_runtime = true;
+    tyir::set_availability(block, availability);
 }
 
 // ─── Block lowering ──────────────────────────────────────────────────────────
@@ -2557,7 +2499,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
             continue;
         if (!target[i].break_ty.has_value()) {
             target[i].break_ty = source[i].break_ty;
-            target[i].break_ct_available = source[i].break_ct_available;
+            target[i].break_availability = source[i].break_availability;
             continue;
         }
 
@@ -2567,9 +2509,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
         if (!joined)
             return std::unexpected(std::move(joined.error()));
         target[i].break_ty = *joined;
-        if (source[i].break_ct_available.has_value()) {
-            target[i].break_ct_available =
-                target[i].break_ct_available.value_or(true) && *source[i].break_ct_available;
+        if (source[i].break_availability.has_value()) {
+            target[i].break_availability = tyir::availability_join(
+                target[i].break_availability.value_or(tyir::availability_ct()),
+                *source[i].break_availability);
         }
     }
     return {};
@@ -2604,7 +2547,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 return LoweredPlace{
                     tyir::make_ty_expr(
                         expr->span, tyir::LocalRef{node.head, tyir::ValueUseKind::Borrow}, local.ty,
-                        local.ct_available, local.runtime_evidence),
+                        local.availability),
                     local_index,
                 };
             } else if constexpr (std::is_same_v<N, ast::FieldAccessExpr>) {
@@ -2636,15 +2579,14 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 tyir::Ty lowered_field_ty =
                     propagate_runtime_tag(*field_ty, base->expr->ty.is_runtime);
-                const bool field_ct_available = expr_value_is_ct_available(base->expr);
-                const auto field_runtime_evidence = base->expr->runtime_evidence;
+                const tyir::Availability field_availability = base->expr->availability;
 
                 return LoweredPlace{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{
                             std::move(base->expr), node.field, tyir::ValueUseKind::Borrow},
-                        lowered_field_ty, field_ct_available, field_runtime_evidence),
+                        lowered_field_ty, field_availability),
                     base->owner_local,
                 };
             } else {
@@ -2744,7 +2686,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     return LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::LocalRef{node.head, use_kind}, local.ty,
-                            local.ct_available, local.runtime_evidence),
+                            local.availability),
                         {},
                         local.ty.is_ref() ? local.borrowed_local : std::nullopt,
                     };
@@ -2805,8 +2747,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     cstc::symbol::Symbol, cstc::span::SourceSpan, cstc::symbol::SymbolHash>
                     seen_fields;
                 seen_fields.reserve(node.fields.size());
-                bool fields_ct_available = true;
-                std::optional<tyir::TyRuntimeEvidence> fields_runtime_evidence;
+                tyir::Availability fields_availability = tyir::availability_ct();
                 bool fields_have_runtime_dependency = false;
 
                 for (const ast::StructInitField& field : node.fields) {
@@ -2841,12 +2782,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                             + "', found '" + val->expr->ty.display() + "'");
 
                     append_temp_borrows(temp_borrows, std::move(val->temp_borrows));
-                    fields_ct_available =
-                        fields_ct_available && expr_value_is_ct_available(val->expr);
+                    fields_availability =
+                        tyir::availability_join(fields_availability, val->expr->availability);
                     fields_have_runtime_dependency = fields_have_runtime_dependency
                                                   || type_has_runtime_dependency(val->expr->ty);
-                    fields_runtime_evidence = first_runtime_evidence(
-                        fields_runtime_evidence, val->expr->runtime_evidence);
 
                     lowered_fields.push_back(
                         tyir::TyStructInitField{field.name, std::move(val->expr), field.span});
@@ -2873,7 +2812,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         tyir::TyStructInit{
                             type_name, std::move(lowered_generic_args), std::move(lowered_fields)},
-                        result_ty, fields_ct_available, fields_runtime_evidence),
+                        result_ty, fields_availability),
                     {},
                     std::nullopt,
                 };
@@ -2897,13 +2836,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             temp_borrows.push_back(*place->owner_local);
                         }
                         const tyir::Ty ref_ty = tyir::ty::ref(place->expr->ty);
-                        const bool borrow_ct_available = expr_value_is_ct_available(place->expr);
-                        const auto borrow_runtime_evidence = place->expr->runtime_evidence;
+                        const tyir::Availability borrow_availability = place->expr->availability;
 
                         return LoweredExpr{
                             tyir::make_ty_expr(
                                 expr->span, tyir::TyBorrow{std::move(place->expr)}, ref_ty,
-                                borrow_ct_available, borrow_runtime_evidence),
+                                borrow_availability),
                             std::move(temp_borrows),
                             place->owner_local,
                         };
@@ -2914,24 +2852,22 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(rhs.error()));
 
                     if (rhs->expr->ty.is_never()) {
-                        const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
-                        const auto borrow_runtime_evidence = rhs->expr->runtime_evidence;
+                        const tyir::Availability borrow_availability = rhs->expr->availability;
                         return LoweredExpr{
                             tyir::make_ty_expr(
                                 expr->span, tyir::TyBorrow{std::move(rhs->expr)}, tyir::ty::never(),
-                                borrow_ct_available, borrow_runtime_evidence),
+                                borrow_availability),
                             std::move(rhs->temp_borrows),
                             std::nullopt,
                         };
                     }
                     const tyir::Ty ref_ty = tyir::ty::ref(rhs->expr->ty);
-                    const bool borrow_ct_available = expr_value_is_ct_available(rhs->expr);
-                    const auto borrow_runtime_evidence = rhs->expr->runtime_evidence;
+                    const tyir::Availability borrow_availability = rhs->expr->availability;
 
                     return LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::TyBorrow{std::move(rhs->expr)}, ref_ty,
-                            borrow_ct_available, borrow_runtime_evidence),
+                            borrow_availability),
                         std::move(rhs->temp_borrows),
                         std::nullopt,
                     };
@@ -2961,12 +2897,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         result_ty = unary_result_type(rhs->expr->ty, tyir::ty::bool_());
                     }
 
-                    const bool unary_ct_available = expr_value_is_ct_available(rhs->expr);
-                    const auto unary_runtime_evidence = rhs->expr->runtime_evidence;
+                    const tyir::Availability unary_availability = rhs->expr->availability;
                     auto lowered = LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::TyUnary{node.op, std::move(rhs->expr)}, result_ty,
-                            unary_ct_available, unary_runtime_evidence),
+                            unary_availability),
                         {},
                         std::nullopt,
                     };
@@ -3054,15 +2989,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     result_ty = binary_result_type(lhs->expr->ty, rhs->expr->ty, tyir::ty::bool_());
                     break;
                 }
-                const bool binary_ct_available =
-                    expr_value_is_ct_available(lhs->expr) && expr_value_is_ct_available(rhs->expr);
-                const auto binary_runtime_evidence = first_runtime_evidence(
-                    lhs->expr->runtime_evidence, rhs->expr->runtime_evidence);
+                const tyir::Availability binary_availability =
+                    tyir::availability_join(lhs->expr->availability, rhs->expr->availability);
                 auto lowered = LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyBinary{node.op, std::move(lhs->expr), std::move(rhs->expr)},
-                        std::move(result_ty), binary_ct_available, binary_runtime_evidence),
+                        std::move(result_ty), binary_availability),
                     {},
                     std::nullopt,
                 };
@@ -3086,12 +3019,11 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 const auto* access = std::get_if<tyir::TyFieldAccess>(&place->expr->node);
                 assert(access != nullptr);
-                const bool field_ct_available = expr_value_is_ct_available(place->expr);
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span,
                         tyir::TyFieldAccess{access->base, access->field, tyir::ValueUseKind::Copy},
-                        place->expr->ty, field_ct_available, place->expr->runtime_evidence),
+                        place->expr->ty, place->expr->availability),
                     {},
                     place->expr->ty.is_ref() ? place->owner_local : std::nullopt,
                 };
@@ -3149,15 +3081,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 std::vector<tyir::TyExprPtr> lowered_args;
                 lowered_args.reserve(node.args.size());
                 std::vector<std::size_t> temp_borrows;
-                std::optional<tyir::TyRuntimeEvidence> args_runtime_evidence;
 
                 for (const ast::ExprPtr& arg_expr : node.args) {
                     auto arg = lower_expr(arg_expr, ctx);
                     if (!arg)
                         return std::unexpected(std::move(arg.error()));
                     append_temp_borrows(temp_borrows, std::move(arg->temp_borrows));
-                    args_runtime_evidence =
-                        first_runtime_evidence(args_runtime_evidence, arg->expr->runtime_evidence);
                     lowered_args.push_back(std::move(arg->expr));
                 }
 
@@ -3251,32 +3180,32 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
-                    const bool call_ct_available = all_exprs_ct_available(lowered_args);
-                    const auto call_runtime_evidence = first_runtime_evidence(
-                        args_runtime_evidence,
-                        type_has_runtime_dependency(resolved_return_shape)
-                            ? runtime_evidence_at(expr->span, "runtime-result call")
-                            : std::nullopt);
+                    tyir::Availability call_availability = availability_from_exprs(lowered_args);
+                    if (type_has_runtime_dependency(resolved_return_shape)) {
+                        call_availability = tyir::availability_join(
+                            call_availability,
+                            runtime_availability_at(expr->span, "runtime-result call"));
+                    }
 
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyCall{
                             fn_name, std::move(concrete_generic_args), std::move(lowered_args)},
-                        lifted_return_ty, call_ct_available, call_runtime_evidence);
+                        lifted_return_ty, call_availability);
                 } else {
                     const tyir::Ty lifted_return_ty =
                         lift_call_result_type(resolved_return_ty, lowered_args);
-                    const bool call_ct_available = all_exprs_ct_available(lowered_args);
-                    const auto call_runtime_evidence = first_runtime_evidence(
-                        args_runtime_evidence,
-                        type_has_runtime_dependency(resolved_return_shape)
-                            ? runtime_evidence_at(expr->span, "runtime-result call")
-                            : std::nullopt);
+                    tyir::Availability call_availability = availability_from_exprs(lowered_args);
+                    if (type_has_runtime_dependency(resolved_return_shape)) {
+                        call_availability = tyir::availability_join(
+                            call_availability,
+                            runtime_availability_at(expr->span, "runtime-result call"));
+                    }
                     lowered_expr = tyir::make_ty_expr(
                         expr->span,
                         tyir::TyDeferredGenericCall{
                             fn_name, std::move(resolved_generic_args), std::move(lowered_args)},
-                        lifted_return_ty, call_ct_available, call_runtime_evidence);
+                        lifted_return_ty, call_availability);
                 }
 
                 auto lowered = LoweredExpr{
@@ -3307,8 +3236,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty, false,
-                        runtime_evidence_at(expr->span, "runtime block")),
+                        expr->span, tyir::TyRuntimeBlock{std::move(block_ptr)}, result_ty,
+                        runtime_availability_at(expr->span, "runtime block")),
                     {},
                     std::nullopt,
                 };
@@ -3321,12 +3250,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     return std::unexpected(std::move(block.error()));
                 tyir::Ty block_ty = block->ty;
                 auto block_ptr = std::make_shared<tyir::TyBlock>(std::move(*block));
-                const bool block_ct_available = block_ptr->ct_available;
-                const auto block_runtime_evidence = block_ptr->runtime_evidence;
+                const tyir::Availability block_availability = block_ptr->availability;
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, std::move(block_ptr), block_ty, block_ct_available,
-                        block_runtime_evidence),
+                        expr->span, std::move(block_ptr), block_ty, block_availability),
                     {},
                     std::nullopt,
                 };
@@ -3353,10 +3280,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 const bool then_reaches_join = block_can_fallthrough(*then_ptr);
 
                 tyir::Ty result_ty = then_ptr->ty;
-                const bool condition_ct_available = expr_value_is_ct_available(cond->expr);
-                bool if_ct_available = condition_ct_available && then_ptr->ct_available;
-                std::optional<tyir::TyRuntimeEvidence> if_runtime_evidence = first_runtime_evidence(
-                    cond->expr->runtime_evidence, then_ptr->runtime_evidence);
+                tyir::Availability if_availability =
+                    tyir::availability_join(cond->expr->availability, then_ptr->availability);
 
                 std::optional<tyir::TyExprPtr> else_branch;
                 if (node.else_branch.has_value()) {
@@ -3390,9 +3315,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     if (expr_can_fallthrough(*else_val->expr))
                         ctx.scope.merge_from(else_ctx.scope);
 
-                    if_ct_available = if_ct_available && expr_value_is_ct_available(else_val->expr);
-                    if_runtime_evidence = first_runtime_evidence(
-                        if_runtime_evidence, else_val->expr->runtime_evidence);
+                    if_availability =
+                        tyir::availability_join(if_availability, else_val->expr->availability);
                     else_branch = std::move(else_val->expr);
                 } else {
                     // No else branch: result type is Unit
@@ -3408,8 +3332,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
 
                 if (result_ty.is_ref())
                     return make_error(expr->span, "'if' expressions cannot yield references yet");
-                if (if_runtime_evidence.has_value()) {
-                    if_ct_available = false;
+                if (if_availability.evidence.has_value()) {
                     if (!result_ty.is_never())
                         result_ty.is_runtime = true;
                 }
@@ -3419,7 +3342,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         tyir::TyIf{
                             std::move(cond->expr), std::move(then_ptr), std::move(else_branch)},
-                        result_ty, if_ct_available, if_runtime_evidence),
+                        result_ty, if_availability),
                     {},
                     std::nullopt,
                 };
@@ -3438,26 +3361,25 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 //   - bare break     → Unit
                 //   - break expr     → expr type
                 const tyir::Ty loop_ty = ctx.current_loop().break_ty.value_or(tyir::ty::never());
-                const bool loop_ct_available = ctx.current_loop().break_ct_available.value_or(true);
+                const tyir::Availability break_availability =
+                    ctx.current_loop().break_availability.value_or(tyir::availability_ct());
                 if (loop_ty.is_ref()) {
                     ctx.pop_loop();
                     return make_error(expr->span, "loop expressions cannot yield references yet");
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                std::optional<tyir::TyRuntimeEvidence> loop_runtime_evidence =
-                    body_ptr->runtime_evidence;
+                tyir::Availability loop_availability =
+                    tyir::availability_join(break_availability, body_ptr->availability);
                 tyir::Ty lowered_loop_ty = loop_ty;
-                bool lowered_loop_ct_available = loop_ct_available;
-                if (loop_runtime_evidence.has_value()) {
-                    lowered_loop_ct_available = false;
+                if (loop_availability.evidence.has_value()) {
                     if (!lowered_loop_ty.is_never())
                         lowered_loop_ty.is_runtime = true;
                 }
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span, tyir::TyLoop{std::move(body_ptr)}, lowered_loop_ty,
-                        lowered_loop_ct_available, loop_runtime_evidence),
+                        loop_availability),
                     {},
                     std::nullopt,
                 };
@@ -3477,7 +3399,6 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                                   + cond->expr->ty.display() + "'");
                 }
                 release_temp_borrows(ctx, cond->temp_borrows);
-                const bool condition_ct_available = expr_value_is_ct_available(cond->expr);
 
                 ctx.push_loop(LoopKind::While);
                 auto body = lower_block(*node.body, ctx);
@@ -3487,20 +3408,16 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                std::optional<tyir::TyRuntimeEvidence> while_runtime_evidence =
-                    first_runtime_evidence(
-                        cond->expr->runtime_evidence, body_ptr->runtime_evidence);
-                bool while_ct_available = condition_ct_available && body_ptr->ct_available;
+                const tyir::Availability while_availability =
+                    tyir::availability_join(cond->expr->availability, body_ptr->availability);
                 tyir::Ty while_ty = tyir::ty::unit();
-                if (while_runtime_evidence.has_value()) {
-                    while_ct_available = false;
+                if (while_availability.evidence.has_value())
                     while_ty.is_runtime = true;
-                }
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
                         expr->span, tyir::TyWhile{std::move(cond->expr), std::move(body_ptr)},
-                        while_ty, while_ct_available, while_runtime_evidence),
+                        while_ty, while_availability),
                     {},
                     std::nullopt,
                 };
@@ -3512,8 +3429,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 ctx.scope.push();
 
                 std::optional<tyir::TyForInit> lowered_init;
-                bool for_ct_available = true;
-                std::optional<tyir::TyRuntimeEvidence> for_runtime_evidence;
+                tyir::Availability for_availability = tyir::availability_ct();
 
                 if (node.init.has_value()) {
                     const auto& init_var = *node.init;
@@ -3524,7 +3440,6 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             return std::unexpected(std::move(init_expr.error()));
                         }
                         tyir::Ty init_ty;
-                        bool init_ct_available = true;
                         if (init_let->type_annotation.has_value()) {
                             auto ann = lower_type(
                                 *init_let->type_annotation, ctx.env, init_let->span,
@@ -3567,10 +3482,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 return std::unexpected(std::move(ct_check.error()));
                             }
                             init_ty = *ann;
-                            init_ct_available = expr_value_is_ct_available(init_expr->expr);
                         } else {
                             init_ty = init_expr->expr->ty;
-                            init_ct_available = expr_value_is_ct_available(init_expr->expr);
                         }
 
                         std::optional<std::size_t> borrowed_local;
@@ -3580,17 +3493,16 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         }
                         if (!init_let->discard && init_let->name.is_valid()
                             && !ctx.scope.insert(
-                                init_let->name, init_ty, borrowed_local, init_ct_available,
-                                init_expr->expr->runtime_evidence)) {
+                                init_let->name, init_ty, borrowed_local,
+                                init_expr->expr->availability)) {
                             ctx.scope.pop();
                             return make_error(
                                 init_let->span, "duplicate local binding '"
                                                     + std::string(init_let->name.as_str()) + "'");
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
-                        for_ct_available = for_ct_available && init_ct_available;
-                        for_runtime_evidence = first_runtime_evidence(
-                            for_runtime_evidence, init_expr->expr->runtime_evidence);
+                        for_availability = tyir::availability_join(
+                            for_availability, init_expr->expr->availability);
                         lowered_init = tyir::TyForInit{
                             init_let->discard, init_let->name, init_ty, std::move(init_expr->expr),
                             init_let->span};
@@ -3603,10 +3515,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             return std::unexpected(std::move(init_expr.error()));
                         }
                         release_temp_borrows(ctx, init_expr->temp_borrows);
-                        for_ct_available =
-                            for_ct_available && expr_value_is_ct_available(init_expr->expr);
-                        for_runtime_evidence = first_runtime_evidence(
-                            for_runtime_evidence, init_expr->expr->runtime_evidence);
+                        for_availability = tyir::availability_join(
+                            for_availability, init_expr->expr->availability);
                         // Treat as a discard init — wrap in TyForInit with discard=true
                         lowered_init = tyir::TyForInit{
                             true, cstc::symbol::kInvalidSymbol, init_expr->expr->ty,
@@ -3631,9 +3541,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 + cond->expr->ty.display() + "'");
                     }
                     release_temp_borrows(ctx, cond->temp_borrows);
-                    for_ct_available = for_ct_available && expr_value_is_ct_available(cond->expr);
-                    for_runtime_evidence =
-                        first_runtime_evidence(for_runtime_evidence, cond->expr->runtime_evidence);
+                    for_availability =
+                        tyir::availability_join(for_availability, cond->expr->availability);
                     lowered_cond = std::move(cond->expr);
                 }
 
@@ -3648,9 +3557,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                 }
                 loop_ctx.pop_loop();
                 auto body_ptr = std::make_shared<tyir::TyBlock>(std::move(*body));
-                for_ct_available = for_ct_available && body_ptr->ct_available;
-                for_runtime_evidence =
-                    first_runtime_evidence(for_runtime_evidence, body_ptr->runtime_evidence);
+                for_availability =
+                    tyir::availability_join(for_availability, body_ptr->availability);
 
                 std::optional<tyir::TyExprPtr> lowered_step;
                 if (node.step.has_value()) {
@@ -3660,19 +3568,16 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         return std::unexpected(std::move(step.error()));
                     }
                     release_temp_borrows(loop_ctx, step->temp_borrows);
-                    for_ct_available = for_ct_available && expr_value_is_ct_available(step->expr);
-                    for_runtime_evidence =
-                        first_runtime_evidence(for_runtime_evidence, step->expr->runtime_evidence);
+                    for_availability =
+                        tyir::availability_join(for_availability, step->expr->availability);
                     lowered_step = std::move(step->expr);
                 }
 
                 ctx.scope.pop();
 
                 tyir::Ty for_ty = tyir::ty::unit();
-                if (for_runtime_evidence.has_value()) {
-                    for_ct_available = false;
+                if (for_availability.evidence.has_value())
                     for_ty.is_runtime = true;
-                }
 
                 return LoweredExpr{
                     tyir::make_ty_expr(
@@ -3680,7 +3585,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         tyir::TyFor{
                             std::move(lowered_init), std::move(lowered_cond),
                             std::move(lowered_step), std::move(body_ptr)},
-                        for_ty, for_ct_available, for_runtime_evidence),
+                        for_ty, for_availability),
                     {},
                     std::nullopt,
                 };
@@ -3713,26 +3618,26 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     // Re-acquire the reference after recursion.
                     auto& loop_ctx = ctx.current_loop();
                     const tyir::Ty& val_ty = val->expr->ty;
-                    const bool break_ct_available = expr_value_is_ct_available(val->expr);
+                    const tyir::Availability break_availability = val->expr->availability;
                     if (!loop_ctx.break_ty.has_value()) {
                         loop_ctx.break_ty = val_ty;
-                        loop_ctx.break_ct_available = break_ct_available;
+                        loop_ctx.break_availability = break_availability;
                     } else {
                         const tyir::Ty& prev = *loop_ctx.break_ty;
                         auto joined = join_loop_break_types(prev, val_ty, expr->span, ctx);
                         if (!joined)
                             return std::unexpected(std::move(joined.error()));
                         loop_ctx.break_ty = *joined;
-                        loop_ctx.break_ct_available =
-                            loop_ctx.break_ct_available.value_or(true) && break_ct_available;
+                        loop_ctx.break_availability = tyir::availability_join(
+                            loop_ctx.break_availability.value_or(tyir::availability_ct()),
+                            break_availability);
                     }
 
                     release_temp_borrows(ctx, val->temp_borrows);
-                    const auto break_runtime_evidence = val->expr->runtime_evidence;
                     return LoweredExpr{
                         tyir::make_ty_expr(
                             expr->span, tyir::TyBreak{std::move(val->expr)}, tyir::ty::never(),
-                            true, break_runtime_evidence),
+                            break_availability),
                         {},
                         std::nullopt,
                     };
@@ -3744,7 +3649,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     // Bare break in `loop` contributes Unit
                     if (!loop_ctx.break_ty.has_value()) {
                         loop_ctx.break_ty = tyir::ty::unit();
-                        loop_ctx.break_ct_available = true;
+                        loop_ctx.break_availability = tyir::availability_ct();
                     } else {
                         const tyir::Ty& prev = *loop_ctx.break_ty;
                         auto joined =
@@ -3752,7 +3657,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         if (!joined)
                             return std::unexpected(std::move(joined.error()));
                         loop_ctx.break_ty = *joined;
-                        loop_ctx.break_ct_available = loop_ctx.break_ct_available.value_or(true);
+                        loop_ctx.break_availability = tyir::availability_join(
+                            loop_ctx.break_availability.value_or(tyir::availability_ct()),
+                            tyir::availability_ct());
                     }
                 }
                 // Bare break in while/for: no type tracking needed
@@ -3804,12 +3711,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
                             expr->span, "bare 'return' in function returning '"
                                             + ctx.current_return_ty.display() + "'");
                 }
-                const auto return_runtime_evidence =
-                    lowered_val.has_value() ? (*lowered_val)->runtime_evidence : std::nullopt;
+                const tyir::Availability return_availability = lowered_val.has_value()
+                                                                 ? (*lowered_val)->availability
+                                                                 : tyir::availability_ct();
                 return LoweredExpr{
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyReturn{std::move(lowered_val)}, tyir::ty::never(), true,
-                        return_runtime_evidence),
+                        expr->span, tyir::TyReturn{std::move(lowered_val)}, tyir::ty::never(),
+                        return_availability),
                     {},
                     std::nullopt,
                 };
@@ -3820,7 +3728,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
         },
         expr->node);
     if (lowered.has_value()) {
-        tyir::refresh_availability(*lowered->expr);
+        tyir::set_availability(*lowered->expr, lowered->expr->availability);
         lowered->deferred_generic_probe_validation = ctx.defer_generic_probe_validation;
     }
     return lowered;
@@ -3847,7 +3755,9 @@ static std::expected<void, LowerError> merge_loop_break_types(
     };
     ctx.scope.push();
     for (const tyir::TyParam& p : ty_params) {
-        if (!ctx.scope.insert(p.name, p.ty, std::nullopt, p.requires_ct()))
+        const tyir::Availability param_availability =
+            p.requires_ct() ? tyir::availability_ct() : tyir::availability_rt();
+        if (!ctx.scope.insert(p.name, p.ty, std::nullopt, param_availability))
             return make_error(p.span, "duplicate parameter '" + std::string(p.name.as_str()) + "'");
     }
 
@@ -3866,13 +3776,13 @@ static std::expected<void, LowerError> merge_loop_break_types(
     }
 
     const bool implicit_unit_result = !sig.has_explicit_return_type && sig.return_ty.is_unit();
-    if (body->runtime_evidence.has_value() && !sig.return_ty.is_runtime && !fn.is_runtime
+    if (body->availability.evidence.has_value() && !sig.return_ty.is_runtime && !fn.is_runtime
         && !implicit_unit_result) {
         return make_error(
-            body->runtime_evidence->span,
+            body->availability.evidence->span,
             "function '" + display_decl_name(fn)
                 + "' body has runtime dependence not reflected in its return type: "
-                + body->runtime_evidence->reason);
+                + body->availability.evidence->reason);
     }
 
     // Check that body type matches declared return type (when a tail is present)

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -344,8 +344,8 @@ using TypeSubstitution =
     return erased;
 }
 
-[[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
-    return tyir::is_ct_available(expr);
+[[nodiscard]] static bool expr_value_satisfies_ct_requirement(const tyir::TyExprPtr& expr) {
+    return expr != nullptr && tyir::is_ct_required_available(expr->availability);
 }
 
 [[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
@@ -956,7 +956,7 @@ struct LowerCtx {
     const tyir::Ty& expected_ty, cstc::span::SourceSpan span) {
     if (param_index >= sig.param_requirements.size()
         || sig.param_requirements[param_index] != tyir::ParamRequirement::CtRequired
-        || expr_value_is_ct_available(arg)) {
+        || expr_value_satisfies_ct_requirement(arg)) {
         return {};
     }
 
@@ -972,7 +972,7 @@ struct LowerCtx {
 [[nodiscard]] static std::expected<void, LowerError> require_ct_annotation_value(
     bool requires_ct, const tyir::TyExprPtr& value, const tyir::Ty& expected_ty,
     cstc::span::SourceSpan span, std::string_view context) {
-    if (!requires_ct || expr_value_is_ct_available(value))
+    if (!requires_ct || expr_value_satisfies_ct_requirement(value))
         return {};
 
     return make_error(
@@ -1373,6 +1373,15 @@ struct LoweredExpr {
 [[nodiscard]] static tyir::Availability
     runtime_availability_at(cstc::span::SourceSpan span, std::string reason) {
     return tyir::availability_rt(runtime_evidence_at(span, std::move(reason)));
+}
+
+[[nodiscard]] static tyir::Availability
+    parameter_declaration_availability(const tyir::TyParam& param) {
+    if (param.requires_ct())
+        return tyir::availability_ct();
+    if (type_has_runtime_dependency(param.ty))
+        return runtime_availability_at(param.span, "runtime parameter");
+    return tyir::availability_runtime_allowed_param();
 }
 
 [[nodiscard]] static tyir::Availability
@@ -2105,12 +2114,7 @@ struct ParamReferenceVisitor {
         }
 
         for (const tyir::TyParam& param : *params) {
-            tyir::Availability param_availability = tyir::availability_ct();
-            if (!param.requires_ct()) {
-                param_availability = type_has_runtime_dependency(param.ty)
-                                       ? runtime_availability_at(param.span, "runtime parameter")
-                                       : tyir::availability_rt();
-            }
+            const tyir::Availability param_availability = parameter_declaration_availability(param);
             if (!ctx.scope.insert(param.name, param.ty, std::nullopt, param_availability)) {
                 ctx.scope.pop();
                 return make_error(
@@ -3825,12 +3829,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
     };
     ctx.scope.push();
     for (const tyir::TyParam& p : ty_params) {
-        tyir::Availability param_availability = tyir::availability_ct();
-        if (!p.requires_ct()) {
-            param_availability = type_has_runtime_dependency(p.ty)
-                                   ? runtime_availability_at(p.span, "runtime parameter")
-                                   : tyir::availability_rt();
-        }
+        const tyir::Availability param_availability = parameter_declaration_availability(p);
         if (!ctx.scope.insert(p.name, p.ty, std::nullopt, param_availability))
             return make_error(p.span, "duplicate parameter '" + std::string(p.name.as_str()) + "'");
     }

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -2604,7 +2604,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         expr->span,
                         "field access on non-struct type '" + base->expr->ty.display() + "'");
 
-                const tyir::TyFieldDecl* field_decl = ctx.env.field_decl(base->expr->ty.name, node.field);
+                const tyir::TyFieldDecl* field_decl =
+                    ctx.env.field_decl(base->expr->ty.name, node.field);
                 if (field_decl == nullptr)
                     return make_error(
                         expr->span, "no field '" + std::string(node.field.as_str())
@@ -2619,7 +2620,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         base->expr->ty.name.as_str());
                     if (!subst)
                         return std::unexpected(std::move(subst.error()));
-                    field_ty = annotate_type_semantics(apply_substitution(field_ty, *subst), ctx.env);
+                    field_ty =
+                        annotate_type_semantics(apply_substitution(field_ty, *subst), ctx.env);
                 }
                 tyir::Ty lowered_field_ty =
                     propagate_runtime_tag(field_ty, base->expr->ty.is_runtime);

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -793,10 +793,6 @@ struct LowerCtx {
         return true;
 
     if (is_generic_param_ty(resolved_actual, generic_params)) {
-        if (resolved_actual.is_runtime && !resolved_expected.is_runtime
-            && !is_generic_param_ty(resolved_expected, generic_params)) {
-            return false;
-        }
         return bind_tentative_generic_substitution(
             resolved_actual, resolved_expected, generic_params, subst);
     }
@@ -2064,8 +2060,12 @@ struct ParamReferenceVisitor {
         }
 
         for (const tyir::TyParam& param : *params) {
-            const tyir::Availability param_availability =
-                param.requires_ct() ? tyir::availability_ct() : tyir::availability_rt();
+            tyir::Availability param_availability = tyir::availability_ct();
+            if (!param.requires_ct()) {
+                param_availability = type_has_runtime_dependency(param.ty)
+                                       ? runtime_availability_at(param.span, "runtime parameter")
+                                       : tyir::availability_rt();
+            }
             if (!ctx.scope.insert(param.name, param.ty, std::nullopt, param_availability)) {
                 ctx.scope.pop();
                 return make_error(
@@ -2252,11 +2252,10 @@ struct ParamReferenceVisitor {
                     if (!resolved_init)
                         return std::unexpected(std::move(resolved_init.error()));
                     init->expr = std::move(*resolved_init);
-                    if (!compatible(init->expr->ty, *ann)
+                    if (!call_argument_compatible(init->expr->ty, *ann)
                         && !should_defer_generic_probe_failure(
                             init->expr->ty, *ann, ctx, init->deferred_generic_probe_validation)) {
-                        if (s.type_annotation->requires_ct
-                            && call_argument_compatible(init->expr->ty, *ann)) {
+                        if (s.type_annotation->requires_ct) {
                             auto ct_check = require_ct_annotation_value(
                                 true, init->expr, *ann, s.span, "let binding");
                             if (!ct_check)
@@ -3455,11 +3454,10 @@ static std::expected<void, LowerError> merge_loop_break_types(
                                 return std::unexpected(std::move(resolved_init.error()));
                             }
                             init_expr->expr = std::move(*resolved_init);
-                            if (!compatible(init_expr->expr->ty, *ann)
+                            if (!call_argument_compatible(init_expr->expr->ty, *ann)
                                 && !should_defer_generic_probe_failure(
                                     init_expr->expr->ty, *ann, ctx)) {
-                                if (init_let->type_annotation->requires_ct
-                                    && call_argument_compatible(init_expr->expr->ty, *ann)) {
+                                if (init_let->type_annotation->requires_ct) {
                                     auto ct_check = require_ct_annotation_value(
                                         true, init_expr->expr, *ann, init_let->span,
                                         "for-init binding");
@@ -3694,7 +3692,7 @@ static std::expected<void, LowerError> merge_loop_break_types(
                     if (!resolved_val)
                         return std::unexpected(std::move(resolved_val.error()));
                     val->expr = std::move(*resolved_val);
-                    if (!compatible(val->expr->ty, ctx.current_return_ty)
+                    if (!call_argument_compatible(val->expr->ty, ctx.current_return_ty)
                         && !should_defer_generic_probe_failure(
                             val->expr->ty, ctx.current_return_ty, ctx,
                             val->deferred_generic_probe_validation))
@@ -3755,8 +3753,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
     };
     ctx.scope.push();
     for (const tyir::TyParam& p : ty_params) {
-        const tyir::Availability param_availability =
-            p.requires_ct() ? tyir::availability_ct() : tyir::availability_rt();
+        tyir::Availability param_availability = tyir::availability_ct();
+        if (!p.requires_ct()) {
+            param_availability = type_has_runtime_dependency(p.ty)
+                                   ? runtime_availability_at(p.span, "runtime parameter")
+                                   : tyir::availability_rt();
+        }
         if (!ctx.scope.insert(p.name, p.ty, std::nullopt, param_availability))
             return make_error(p.span, "duplicate parameter '" + std::string(p.name.as_str()) + "'");
     }
@@ -3786,7 +3788,8 @@ static std::expected<void, LowerError> merge_loop_break_types(
     }
 
     // Check that body type matches declared return type (when a tail is present)
-    if (body->tail.has_value() && !compatible(body->ty, sig.return_ty) && !implicit_unit_result
+    if (body->tail.has_value() && !call_argument_compatible(body->ty, sig.return_ty)
+        && !implicit_unit_result
         && !should_defer_generic_probe_failure(body->ty, sig.return_ty, ctx))
         return make_error(
             fn.body->span, "function '" + display_decl_name(fn) + "' body type mismatch: expected '"

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -376,7 +376,7 @@ using TypeSubstitution =
 [[nodiscard]] static tyir::Ty
     lift_call_result_type(tyir::Ty result_ty, const std::vector<tyir::TyExprPtr>& args) {
     if (!exprs_can_fallthrough(args))
-        return erase_runtime_qualifiers(result_ty);
+        return tyir::ty::never();
     if (type_has_runtime_dependency(result_ty))
         result_ty.is_runtime = true;
     for (const tyir::TyExprPtr& arg : args) {
@@ -929,7 +929,7 @@ struct LowerCtx {
     if (result_shape.is_never())
         return result_shape;
     if (!exprs_can_fallthrough(args))
-        return erase_runtime_qualifiers(result_shape);
+        return tyir::ty::never();
     for (const tyir::TyExprPtr& arg : args) {
         if (arg != nullptr && type_has_runtime_dependency(arg->ty)) {
             result_shape.is_runtime = true;

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -318,10 +318,10 @@ static void test_fn_with_params_and_return() {
     assert(fn.params[1].name == Symbol::intern("y"));
     assert(fn.params[1].ty == ty::num());
 
-    // Body should have a tail of type num
-    assert(fn.body->ty == ty::num());
+    // Body is runtime-available because ordinary parameters may be runtime inputs.
+    assert(fn.body->ty == ty::num(true));
     assert(fn.body->tail.has_value());
-    assert((*fn.body->tail)->ty == ty::num());
+    assert((*fn.body->tail)->ty == ty::num(true));
 }
 
 static void test_fn_bool_return() {
@@ -428,7 +428,7 @@ static void test_ct_required_param_rejects_forwarded_runtime_allowed_local() {
 static void test_ct_required_let_annotation_rejects_runtime_allowed_param() {
     must_fail_with_message(
         "fn wrap(count: num) -> num { let forwarded: const num = count; forwarded }",
-        "let binding must be compile-time available: expected 'const num', found 'num'");
+        "let binding must be compile-time available: expected 'const num', found 'runtime num'");
 }
 
 static void test_fn_preserves_generic_metadata() {
@@ -471,13 +471,13 @@ static void test_fn_decl_where_clause_allows_parameter_references_in_decl_probe(
 static void test_decl_probe_does_not_relax_matching_body_checks() {
     must_fail_with_constraint_prelude(
         "fn bad<T>(value: T) -> num where decl(value) { value }",
-        "function 'bad' body type mismatch: expected 'num', found 'T'");
+        "function 'bad' body type mismatch: expected 'num', found 'runtime T'");
 }
 
 static void test_decl_probe_inside_disjunction_does_not_relax_matching_body_checks() {
     must_fail_with_constraint_prelude(
         "fn bad<T>(a: T) -> T where true || decl(a + a) { a + a }",
-        "arithmetic operator requires 'num' on left, found 'T'");
+        "arithmetic operator requires 'num' on left, found 'runtime T'");
 }
 
 static void test_struct_where_clause_rejects_return() {
@@ -618,7 +618,8 @@ static void test_decl_probe_keeps_ref_shape_arithmetic_invalid() {
     assert(probe.is_invalid);
     assert(!probe.expr.has_value());
     assert(probe.invalid_reason.has_value());
-    assert(*probe.invalid_reason == "arithmetic operator requires 'num' on left, found '&T'");
+    assert(
+        *probe.invalid_reason == "arithmetic operator requires 'num' on left, found 'runtime &T'");
 }
 
 static void test_decl_probe_defers_generic_let_annotation_validation() {
@@ -664,7 +665,7 @@ static void test_decl_probe_defers_generic_if_join_during_expected_type_resoluti
     const auto& call = std::get<TyCall>((*probe.expr)->node);
     assert(call.fn_name == Symbol::intern("id_num"));
     assert(call.args.size() == 1);
-    assert(call.args[0]->ty == ty::num());
+    assert(call.args[0]->ty == ty::num(true));
     assert(std::holds_alternative<TyIf>(call.args[0]->node));
 }
 
@@ -684,7 +685,7 @@ static void test_decl_probe_reannotates_deferred_generic_if_join_semantics() {
     assert(
         joined.ty
         == ty::named(
-            Symbol::intern("Wrapper"), kInvalidSymbol, ValueSemantics::Copy, false, {ty::num()}));
+            Symbol::intern("Wrapper"), kInvalidSymbol, ValueSemantics::Copy, true, {ty::num()}));
 }
 
 static void test_decl_probe_rejects_conflicting_generic_let_annotation_bindings() {
@@ -779,7 +780,8 @@ static void test_decl_probe_does_not_drive_if_branch_join_inference() {
 
 static void test_decl_probe_does_not_relax_unrelated_body_checks() {
     must_fail_with_message(
-        "fn f<T>(a: T) -> bool where decl(1 + 1) { !a }", "unary '!' requires 'bool', found 'T'");
+        "fn f<T>(a: T) -> bool where decl(1 + 1) { !a }",
+        "unary '!' requires 'bool', found 'runtime T'");
 }
 
 static void test_decl_runtime_use_is_rejected() {
@@ -814,7 +816,7 @@ static void test_runtime_return_annotation_accepts_plain_value() {
 static void test_runtime_return_type_mismatch_rejected() {
     must_fail_with_message(
         "struct Job; fn unwrap(job: runtime Job) -> Job { job }",
-        "body type mismatch: expected 'Job', found 'runtime Job'");
+        "body has runtime dependence not reflected in its return type");
 }
 
 static void test_runtime_main_return_allowed() {

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -364,6 +364,29 @@ static void test_runtime_fn_return_uses_runtime_sugar() {
     assert(fn.body->ty.is_runtime);
 }
 
+static void test_runtime_allowed_param_marks_body_runtime_without_evidence() {
+    const auto prog = must_lower("fn echo(value: num) -> runtime num { value }");
+    const auto& fn = std::get<TyFnDecl>(prog.items[0]);
+    assert(fn.body->ty == ty::num(true));
+    assert(fn.body->availability.kind == AvailabilityKind::Rt);
+    assert(!fn.body->availability.evidence.has_value());
+    assert(fn.body->tail.has_value());
+    assert((*fn.body->tail)->availability.kind == AvailabilityKind::Rt);
+    assert(!(*fn.body->tail)->availability.evidence.has_value());
+}
+
+static void test_runtime_typed_param_records_runtime_parameter_evidence() {
+    const auto prog = must_lower("struct Job; fn echo(job: runtime Job) -> runtime Job { job }");
+    assert(prog.items.size() == 2);
+    const auto& fn = std::get<TyFnDecl>(prog.items[1]);
+    assert(fn.body->availability.kind == AvailabilityKind::Rt);
+    assert(fn.body->availability.evidence.has_value());
+    assert(fn.body->availability.evidence->reason == "runtime parameter");
+    assert(fn.body->tail.has_value());
+    assert((*fn.body->tail)->availability.evidence.has_value());
+    assert((*fn.body->tail)->availability.evidence->reason == "runtime parameter");
+}
+
 static void test_ct_required_param_requirement_is_preserved() {
     const auto prog = must_lower("fn reserve(count: !runtime num) -> num { count }");
     const auto& fn = std::get<TyFnDecl>(prog.items[0]);
@@ -997,6 +1020,8 @@ int main() {
     test_fn_ref_return_rejected();
     test_runtime_fn_preserves_runtime_markers();
     test_runtime_fn_return_uses_runtime_sugar();
+    test_runtime_allowed_param_marks_body_runtime_without_evidence();
+    test_runtime_typed_param_records_runtime_parameter_evidence();
     test_ct_required_param_requirement_is_preserved();
     test_ct_required_param_rejects_runtime_argument();
     test_ct_required_param_rejects_runtime_block_argument();

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -425,6 +425,21 @@ static void test_ct_required_param_rejects_forwarded_runtime_allowed_local() {
         "argument `count` must be compile-time available");
 }
 
+static void test_ct_required_param_forwards_ct_required_runtime_projection() {
+    const auto prog = must_lower(
+        "struct Box<T> { value: T }"
+        "fn inner(box: !runtime Box<runtime num>) -> num { box.value }"
+        "fn outer(box: !runtime Box<runtime num>) -> num { inner(box) }");
+    const auto& outer = std::get<TyFnDecl>(prog.items[2]);
+    const auto& call = std::get<TyCall>((*outer.body->tail)->node);
+    assert(call.args.size() == 1);
+    assert(call.args[0]->availability.kind == AvailabilityKind::Ct);
+    assert(
+        call.args[0]->ty
+        == ty::named(
+            Symbol::intern("Box"), kInvalidSymbol, ValueSemantics::Copy, false, {ty::num()}));
+}
+
 static void test_ct_required_let_annotation_rejects_runtime_allowed_param() {
     must_fail_with_message(
         "fn wrap(count: num) -> num { let forwarded: const num = count; forwarded }",
@@ -989,6 +1004,7 @@ int main() {
     test_ct_required_param_rejects_forwarded_runtime_allowed_param();
     test_ct_required_param_rejects_invalid_name_with_argument_number();
     test_ct_required_param_rejects_forwarded_runtime_allowed_local();
+    test_ct_required_param_forwards_ct_required_runtime_projection();
     test_ct_required_let_annotation_rejects_runtime_allowed_param();
     test_fn_preserves_generic_metadata();
     test_fn_where_clause_rejects_parameter_references();

--- a/compiler/cstc_tyir_builder/tests/lower_basic.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_basic.cpp
@@ -318,10 +318,11 @@ static void test_fn_with_params_and_return() {
     assert(fn.params[1].name == Symbol::intern("y"));
     assert(fn.params[1].ty == ty::num());
 
-    // Body is runtime-available because ordinary parameters may be runtime inputs.
-    assert(fn.body->ty == ty::num(true));
+    // Body remains compile-time-shaped while retaining symbolic parameter dependence.
+    assert(fn.body->ty == ty::num());
     assert(fn.body->tail.has_value());
-    assert((*fn.body->tail)->ty == ty::num(true));
+    assert((*fn.body->tail)->ty == ty::num());
+    assert(fn.body->availability.depends_on_runtime_allowed_param);
 }
 
 static void test_fn_bool_return() {
@@ -364,14 +365,16 @@ static void test_runtime_fn_return_uses_runtime_sugar() {
     assert(fn.body->ty.is_runtime);
 }
 
-static void test_runtime_allowed_param_marks_body_runtime_without_evidence() {
+static void test_runtime_allowed_param_marks_symbolic_body_dependence() {
     const auto prog = must_lower("fn echo(value: num) -> runtime num { value }");
     const auto& fn = std::get<TyFnDecl>(prog.items[0]);
-    assert(fn.body->ty == ty::num(true));
-    assert(fn.body->availability.kind == AvailabilityKind::Rt);
+    assert(fn.body->ty == ty::num());
+    assert(fn.body->availability.kind == AvailabilityKind::Ct);
+    assert(fn.body->availability.depends_on_runtime_allowed_param);
     assert(!fn.body->availability.evidence.has_value());
     assert(fn.body->tail.has_value());
-    assert((*fn.body->tail)->availability.kind == AvailabilityKind::Rt);
+    assert((*fn.body->tail)->availability.kind == AvailabilityKind::Ct);
+    assert((*fn.body->tail)->availability.depends_on_runtime_allowed_param);
     assert(!(*fn.body->tail)->availability.evidence.has_value());
 }
 
@@ -466,7 +469,7 @@ static void test_ct_required_param_forwards_ct_required_runtime_projection() {
 static void test_ct_required_let_annotation_rejects_runtime_allowed_param() {
     must_fail_with_message(
         "fn wrap(count: num) -> num { let forwarded: const num = count; forwarded }",
-        "let binding must be compile-time available: expected 'const num', found 'runtime num'");
+        "let binding must be compile-time available: expected 'const num', found 'num'");
 }
 
 static void test_fn_preserves_generic_metadata() {
@@ -509,13 +512,13 @@ static void test_fn_decl_where_clause_allows_parameter_references_in_decl_probe(
 static void test_decl_probe_does_not_relax_matching_body_checks() {
     must_fail_with_constraint_prelude(
         "fn bad<T>(value: T) -> num where decl(value) { value }",
-        "function 'bad' body type mismatch: expected 'num', found 'runtime T'");
+        "function 'bad' body type mismatch: expected 'num', found 'T'");
 }
 
 static void test_decl_probe_inside_disjunction_does_not_relax_matching_body_checks() {
     must_fail_with_constraint_prelude(
         "fn bad<T>(a: T) -> T where true || decl(a + a) { a + a }",
-        "arithmetic operator requires 'num' on left, found 'runtime T'");
+        "arithmetic operator requires 'num' on left, found 'T'");
 }
 
 static void test_struct_where_clause_rejects_return() {
@@ -656,8 +659,7 @@ static void test_decl_probe_keeps_ref_shape_arithmetic_invalid() {
     assert(probe.is_invalid);
     assert(!probe.expr.has_value());
     assert(probe.invalid_reason.has_value());
-    assert(
-        *probe.invalid_reason == "arithmetic operator requires 'num' on left, found 'runtime &T'");
+    assert(*probe.invalid_reason == "arithmetic operator requires 'num' on left, found '&T'");
 }
 
 static void test_decl_probe_defers_generic_let_annotation_validation() {
@@ -703,7 +705,7 @@ static void test_decl_probe_defers_generic_if_join_during_expected_type_resoluti
     const auto& call = std::get<TyCall>((*probe.expr)->node);
     assert(call.fn_name == Symbol::intern("id_num"));
     assert(call.args.size() == 1);
-    assert(call.args[0]->ty == ty::num(true));
+    assert(call.args[0]->ty == ty::num());
     assert(std::holds_alternative<TyIf>(call.args[0]->node));
 }
 
@@ -723,7 +725,7 @@ static void test_decl_probe_reannotates_deferred_generic_if_join_semantics() {
     assert(
         joined.ty
         == ty::named(
-            Symbol::intern("Wrapper"), kInvalidSymbol, ValueSemantics::Copy, true, {ty::num()}));
+            Symbol::intern("Wrapper"), kInvalidSymbol, ValueSemantics::Copy, false, {ty::num()}));
 }
 
 static void test_decl_probe_rejects_conflicting_generic_let_annotation_bindings() {
@@ -818,8 +820,7 @@ static void test_decl_probe_does_not_drive_if_branch_join_inference() {
 
 static void test_decl_probe_does_not_relax_unrelated_body_checks() {
     must_fail_with_message(
-        "fn f<T>(a: T) -> bool where decl(1 + 1) { !a }",
-        "unary '!' requires 'bool', found 'runtime T'");
+        "fn f<T>(a: T) -> bool where decl(1 + 1) { !a }", "unary '!' requires 'bool', found 'T'");
 }
 
 static void test_decl_runtime_use_is_rejected() {
@@ -1020,7 +1021,7 @@ int main() {
     test_fn_ref_return_rejected();
     test_runtime_fn_preserves_runtime_markers();
     test_runtime_fn_return_uses_runtime_sugar();
-    test_runtime_allowed_param_marks_body_runtime_without_evidence();
+    test_runtime_allowed_param_marks_symbolic_body_dependence();
     test_runtime_typed_param_records_runtime_parameter_evidence();
     test_ct_required_param_requirement_is_preserved();
     test_ct_required_param_rejects_runtime_argument();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -1473,6 +1473,14 @@ static void test_runtime_field_access_preserves_runtime_tag() {
     assert(fa.base->ty.is_runtime);
 }
 
+static void test_runtime_field_decl_rejects_ct_required_use() {
+    must_fail_with_message(
+        "struct Box { value: runtime num }"
+        "fn reserve(value: !runtime num) -> num { value }"
+        "fn f(box: Box) -> num { reserve(box.value) }",
+        "argument `value` must be compile-time available");
+}
+
 static void test_field_access_unknown_field_error() {
     must_fail(
         "struct Point { x: num }"
@@ -1713,6 +1721,7 @@ int main() {
     test_struct_init_missing_field_error();
     test_field_access();
     test_runtime_field_access_preserves_runtime_tag();
+    test_runtime_field_decl_rejects_ct_required_use();
     test_field_access_unknown_field_error();
     test_borrow_local_binding();
     test_borrow_runtime_field_binding();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -121,7 +121,7 @@ static void test_unit_literal() {
 static void test_param_ref() {
     const auto prog = must_lower("fn f(x: num) -> num { x }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num(true));
+    assert(tail->ty == ty::num());
     assert(std::holds_alternative<LocalRef>(tail->node));
     assert(std::get<LocalRef>(tail->node).name == Symbol::intern("x"));
 }
@@ -170,7 +170,7 @@ static void test_arithmetic() {
              "fn f(x: num, y: num) -> num { x % y }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::num(true));
+        assert((*first_fn(prog).body->tail)->ty == ty::num());
     }
 }
 
@@ -193,7 +193,7 @@ static void test_comparisons() {
              "fn f(x: num, y: num) -> bool { x >= y }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
     }
 }
 
@@ -202,11 +202,11 @@ static void test_comparisons() {
 static void test_equality() {
     {
         const auto prog = must_lower("fn f(x: num, y: num) -> bool { x == y }");
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
     }
     {
         const auto prog = must_lower("fn f(x: bool, y: bool) -> bool { x != y }");
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
     }
 }
 
@@ -222,7 +222,7 @@ static void test_logical() {
              "fn f(a: bool, b: bool) -> bool { a || b }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
     }
 }
 
@@ -516,12 +516,12 @@ static void test_runtime_block_prevents_demotion() {
 
 static void test_unary_negate() {
     const auto prog = must_lower("fn f(x: num) -> num { -x }");
-    assert((*first_fn(prog).body->tail)->ty == ty::num(true));
+    assert((*first_fn(prog).body->tail)->ty == ty::num());
 }
 
 static void test_unary_not() {
     const auto prog = must_lower("fn f(b: bool) -> bool { !b }");
-    assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
+    assert((*first_fn(prog).body->tail)->ty == ty::bool_());
 }
 
 static void test_runtime_unary_negate_preserves_runtime_type() {
@@ -547,17 +547,17 @@ static void test_if_no_else() {
     // Without else: result type is Unit; if becomes the tail expression
     const auto prog = must_lower("fn f(b: bool) { if b { } }");
     const auto& body = *first_fn(prog).body;
-    assert(body.ty == ty::unit(true));
+    assert(body.ty == ty::unit());
     // Parser emits the if as the block's tail expression
     assert(body.tail.has_value());
-    assert((*body.tail)->ty == ty::unit(true));
+    assert((*body.tail)->ty == ty::unit());
     assert(std::holds_alternative<TyIf>((*body.tail)->node));
 }
 
 static void test_if_else() {
     const auto prog = must_lower("fn f(b: bool) -> num { if b { 1 } else { 2 } }");
     const auto& tail = *(*first_fn(prog).body->tail);
-    assert(tail.ty == ty::num(true));
+    assert(tail.ty == ty::num());
     assert(std::holds_alternative<TyIf>(tail.node));
 }
 
@@ -635,7 +635,7 @@ static void test_while() {
     assert(fn_body.tail.has_value());
     const auto& while_expr = *fn_body.tail;
     assert(std::holds_alternative<TyWhile>(while_expr->node));
-    assert(while_expr->ty == ty::unit(true));
+    assert(while_expr->ty == ty::unit());
 }
 
 static void test_runtime_while_condition_accepted() {
@@ -803,7 +803,7 @@ static void test_loop_multiple_breaks_same_type() {
         "  }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num(true));
+    assert(tail->ty == ty::num());
 }
 
 static void test_loop_break_type_mismatch_error() {
@@ -871,7 +871,7 @@ static void test_break_value_in_for_error() {
 static void test_bare_break_in_while_ok() {
     const auto prog = must_lower("fn f(b: bool) { while b { break; } }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::unit(true));
+    assert(tail->ty == ty::unit());
 }
 
 static void test_bare_break_in_for_ok() {
@@ -927,7 +927,7 @@ static void test_break_value_in_loop_nested_inside_while() {
         "  }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num(true));
+    assert(tail->ty == ty::num());
 }
 
 static void test_continue_in_while_ok() {
@@ -1022,7 +1022,7 @@ static void test_if_one_branch_diverges_other_unit() {
     // if b { return; } (no else) — if without else is always Unit
     const auto prog = must_lower("fn f(b: bool) { if b { return; } }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::unit(true));
+    assert(tail->ty == ty::unit());
 }
 
 static void test_if_else_one_branch_diverges() {
@@ -1032,7 +1032,7 @@ static void test_if_else_one_branch_diverges() {
         "  if b { return 1; } else { 42 }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num(true));
+    assert(tail->ty == ty::num());
 }
 
 static void test_if_diverging_then_does_not_leak_move_state() {
@@ -1183,7 +1183,7 @@ static void test_let_annotation_resolves_direct_deferred_call() {
         "fn f(flag: bool) { let x: num = make_default(flag); }");
     const auto& stmt = std::get<TyLetStmt>(second_fn(prog).body->stmts[0]);
     assert(stmt.ty == ty::num());
-    assert(stmt.init->ty == ty::num(true));
+    assert(stmt.init->ty == ty::num());
     const auto& call = std::get<TyCall>(stmt.init->node);
     assert(call.generic_args.size() == 1);
     assert(call.generic_args[0] == ty::num());
@@ -1197,7 +1197,7 @@ static void test_return_type_resolves_deferred_call_through_if_branches() {
     const auto& ret = std::get<TyReturn>(stmt.expr->node);
     assert(ret.value.has_value());
     const auto& if_expr = **ret.value;
-    assert(if_expr.ty == ty::num(true));
+    assert(if_expr.ty == ty::num());
     const auto& branch = std::get<TyIf>(if_expr.node);
     assert(branch.then_block->ty == ty::num());
     assert(branch.then_block->tail.has_value());
@@ -1534,12 +1534,10 @@ static void test_field_access() {
         "struct Point { x: num, y: num }"
         "fn get_x(p: Point) -> num { p.x }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num(true));
+    assert(tail->ty == ty::num());
     const auto& fa = std::get<TyFieldAccess>(tail->node);
     assert(fa.field == Symbol::intern("x"));
-    assert(
-        fa.base->ty
-        == ty::named(Symbol::intern("Point"), kInvalidSymbol, ValueSemantics::Copy, true));
+    assert(fa.base->ty == ty::named(Symbol::intern("Point"), kInvalidSymbol, ValueSemantics::Copy));
 }
 
 static void test_runtime_field_access_preserves_runtime_tag() {

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -265,6 +265,19 @@ static void test_call_unreachable_arg_does_not_taint_plain_result() {
     assert(body.availability.kind == AvailabilityKind::Ct);
 }
 
+static void test_plain_call_with_diverging_argument_becomes_never_in_if_branch() {
+    const auto prog = must_lower(
+        "fn sink(value: num) -> num { value }"
+        "fn f(cond: bool) -> num { if cond { sink((return 1)) } else { true }; 0 }");
+    const auto& stmt = std::get<TyExprStmt>(second_fn(prog).body->stmts[0]);
+    assert(stmt.expr->ty == ty::bool_());
+    const auto& if_expr = std::get<TyIf>(stmt.expr->node);
+    assert(if_expr.then_block->tail.has_value());
+    const auto& call = std::get<TyCall>((*if_expr.then_block->tail)->node);
+    assert((*if_expr.then_block->tail)->ty == ty::never());
+    assert(call.args[0]->ty == ty::never());
+}
+
 static void test_unused_runtime_let_taints_plain_result_function() {
     must_fail_with_message(
         "runtime fn source() -> num { 1 }"
@@ -1206,6 +1219,19 @@ static void test_return_type_resolves_deferred_call_through_if_branches() {
     assert(call.generic_args[0] == ty::num());
 }
 
+static void test_deferred_generic_call_with_diverging_argument_becomes_never_in_if_branch() {
+    const auto prog = must_lower(
+        "fn make_default<T>(flag: bool) -> T { loop {} }"
+        "fn f(cond: bool) -> num { if cond { make_default((return 1)) } else { true }; 0 }");
+    const auto& stmt = std::get<TyExprStmt>(second_fn(prog).body->stmts[0]);
+    assert(stmt.expr->ty == ty::bool_());
+    const auto& if_expr = std::get<TyIf>(stmt.expr->node);
+    assert(if_expr.then_block->tail.has_value());
+    const auto& call = std::get<TyDeferredGenericCall>((*if_expr.then_block->tail)->node);
+    assert((*if_expr.then_block->tail)->ty == ty::never());
+    assert(call.args[0]->ty == ty::never());
+}
+
 static void test_if_branch_join_keeps_runtime_on_deferred_generic_call() {
     must_fail_with_message(
         "runtime fn make_default<T>(flag: bool) -> T { loop {} }"
@@ -1671,6 +1697,7 @@ int main() {
     test_plain_call_accepts_runtime_argument_and_lifts_result();
     test_plain_call_lifted_result_still_prevents_return_demotion();
     test_call_unreachable_arg_does_not_taint_plain_result();
+    test_plain_call_with_diverging_argument_becomes_never_in_if_branch();
     test_unused_runtime_let_taints_plain_result_function();
     test_runtime_expression_statement_taints_plain_result_function();
     test_runtime_block_statement_taints_plain_result_function();
@@ -1793,6 +1820,7 @@ int main() {
     test_let_annotation_resolves_deferred_call_in_block_tail();
     test_let_annotation_resolves_direct_deferred_call();
     test_return_type_resolves_deferred_call_through_if_branches();
+    test_deferred_generic_call_with_diverging_argument_becomes_never_in_if_branch();
     test_if_branch_join_keeps_runtime_on_deferred_generic_call();
     test_expected_type_resolves_nested_deferred_generic_argument();
     test_deferred_resolution_uses_specialized_parameter_type();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -652,6 +652,31 @@ static void test_runtime_for_condition_accepted() {
     assert(for_expr->ty == ty::unit(true));
 }
 
+static void test_for_unreachable_step_does_not_taint_plain_result() {
+    const auto prog = must_lower("fn f() -> num { for (;; runtime { 1 }) { break; }; 0 }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.availability.kind == AvailabilityKind::Ct);
+    assert(body.tail.has_value());
+    assert((*body.tail)->ty == ty::num());
+}
+
+static void test_for_diverging_init_skips_later_runtime_segments() {
+    const auto prog = must_lower(
+        "fn f() -> num { for (return 1; runtime { true }; runtime { 2 }) { runtime { 3 }; }; "
+        "0 }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
+static void test_for_diverging_condition_skips_body_and_step_availability() {
+    const auto prog =
+        must_lower("fn f() -> num { for (; return 1; runtime { 2 }) { runtime { 3 }; }; 0 }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
 static void test_break_and_continue_are_never() {
     const auto prog = must_lower("fn f() { loop { break; continue; } }");
     // loop is the tail of the outer block
@@ -1631,6 +1656,9 @@ int main() {
     test_runtime_while_condition_accepted();
     test_for_loop();
     test_runtime_for_condition_accepted();
+    test_for_unreachable_step_does_not_taint_plain_result();
+    test_for_diverging_init_skips_later_runtime_segments();
+    test_for_diverging_condition_skips_body_and_step_availability();
     test_break_and_continue_are_never();
     test_return_is_never();
     test_runtime_return_payload_marks_body_not_ct_available();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -176,6 +176,13 @@ static void test_arithmetic() {
 
 static void test_arithmetic_type_error() { must_fail("fn f(x: bool) -> num { x + 1 }"); }
 
+static void test_binary_unreachable_rhs_does_not_taint_plain_result() {
+    const auto prog = must_lower("fn f() -> num { (return 1) + runtime { 2 } }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
 // ─── Comparison operators ─────────────────────────────────────────────────────
 
 static void test_comparisons() {
@@ -247,6 +254,15 @@ static void test_plain_call_lifted_result_still_prevents_return_demotion() {
         "fn sink(value: num) -> num { value }"
         "fn main() -> num { sink(source()) }",
         "runtime dependence not reflected in its return type");
+}
+
+static void test_call_unreachable_arg_does_not_taint_plain_result() {
+    const auto prog = must_lower(
+        "runtime fn source(left: num, right: num) -> num { right }"
+        "fn f() -> num { source((return 1), runtime { 2 }) }");
+    const auto& body = *second_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
 }
 
 static void test_unused_runtime_let_taints_plain_result_function() {
@@ -1389,6 +1405,15 @@ static void test_struct_init_lifts_runtime_field() {
     assert(init.fields[1].value->ty == ty::num());
 }
 
+static void test_struct_init_unreachable_field_does_not_taint_plain_result() {
+    const auto prog = must_lower(
+        "struct Pair { left: num, right: num }"
+        "fn f() -> num { Pair { left: return 1, right: runtime { 2 } }; 0 }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
 static void test_generic_struct_init() {
     const auto prog = must_lower(
         "struct Box<T> { value: T }"
@@ -1603,6 +1628,7 @@ int main() {
     test_undefined_variable_error();
     test_arithmetic();
     test_arithmetic_type_error();
+    test_binary_unreachable_rhs_does_not_taint_plain_result();
     test_comparisons();
     test_equality();
     test_equality_type_mismatch_error();
@@ -1610,6 +1636,7 @@ int main() {
     test_runtime_argument_promotion();
     test_plain_call_accepts_runtime_argument_and_lifts_result();
     test_plain_call_lifted_result_still_prevents_return_demotion();
+    test_call_unreachable_arg_does_not_taint_plain_result();
     test_unused_runtime_let_taints_plain_result_function();
     test_runtime_expression_statement_taints_plain_result_function();
     test_runtime_block_statement_taints_plain_result_function();
@@ -1738,6 +1765,7 @@ int main() {
     test_unknown_variant_error();
     test_struct_init();
     test_struct_init_lifts_runtime_field();
+    test_struct_init_unreachable_field_does_not_taint_plain_result();
     test_generic_struct_init();
     test_generic_struct_specialization_tracks_move_semantics();
     test_generic_struct_specialization_keeps_copy_semantics();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -573,7 +573,10 @@ static void test_if_condition_must_be_bool() { must_fail("fn f(x: num) { if x { 
 static void test_runtime_if_condition_accepted() {
     const auto prog = must_lower(
         "fn f() -> runtime num { if flag() { 1 } else { 2 } } runtime fn flag() -> bool { true }");
-    assert((*first_fn(prog).body->tail)->ty == ty::num(true));
+    const auto& tail = *first_fn(prog).body->tail;
+    assert(tail->ty == ty::num(true));
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    assert(tail->availability.evidence.has_value());
 }
 
 static void test_if_else_runtime_join_produces_runtime_type() {
@@ -626,6 +629,8 @@ static void test_runtime_while_condition_accepted() {
     const auto& while_expr = *first_fn(prog).body->tail;
     assert(std::holds_alternative<TyWhile>(while_expr->node));
     assert(while_expr->ty == ty::unit(true));
+    assert(while_expr->availability.kind == AvailabilityKind::Rt);
+    assert(while_expr->availability.evidence.has_value());
 }
 
 static void test_for_loop() {
@@ -666,6 +671,8 @@ static void test_runtime_for_condition_accepted() {
     const auto& for_expr = *first_fn(prog).body->tail;
     assert(std::holds_alternative<TyFor>(for_expr->node));
     assert(for_expr->ty == ty::unit(true));
+    assert(for_expr->availability.kind == AvailabilityKind::Rt);
+    assert(for_expr->availability.evidence.has_value());
 }
 
 static void test_for_unreachable_step_does_not_taint_plain_result() {

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -602,6 +602,21 @@ static void test_if_else_runtime_join_prevents_demotion() {
         "runtime dependence not reflected in its return type");
 }
 
+static void test_if_diverging_condition_skips_branch_availability() {
+    const auto prog = must_lower("fn f() -> num { if (return 1) { runtime { 2 } } else { 3 } }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
+static void test_expected_type_if_diverging_condition_skips_branch_availability() {
+    const auto prog = must_lower(
+        "fn f() -> num { let value: num = if (return 1) { runtime { 2 } } else { 3 }; value }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+}
+
 // ─── Control flow ─────────────────────────────────────────────────────────────
 
 static void test_loop_is_unit() {
@@ -631,6 +646,13 @@ static void test_runtime_while_condition_accepted() {
     assert(while_expr->ty == ty::unit(true));
     assert(while_expr->availability.kind == AvailabilityKind::Rt);
     assert(while_expr->availability.evidence.has_value());
+}
+
+static void test_while_diverging_condition_skips_body_availability() {
+    const auto prog = must_lower("fn f() -> num { while (return 1) { runtime { 2 }; }; 0 }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
 }
 
 static void test_for_loop() {
@@ -1685,9 +1707,12 @@ int main() {
     test_if_else_runtime_join_produces_runtime_type();
     test_if_else_rejects_distinct_nominal_types();
     test_if_else_runtime_join_prevents_demotion();
+    test_if_diverging_condition_skips_branch_availability();
+    test_expected_type_if_diverging_condition_skips_branch_availability();
     test_loop_is_unit();
     test_while();
     test_runtime_while_condition_accepted();
+    test_while_diverging_condition_skips_body_availability();
     test_for_loop();
     test_runtime_for_condition_accepted();
     test_for_unreachable_step_does_not_taint_plain_result();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -286,6 +286,18 @@ static void test_unreachable_runtime_statement_does_not_taint_block() {
     assert(fn.body->availability.kind == AvailabilityKind::Ct);
 }
 
+static void test_resolved_block_tail_can_clear_runtime_projection() {
+    const auto prog = must_lower(
+        "fn make_default<T>() -> T { loop {} }"
+        "fn value() -> num { let result: num = { make_default() }; result }");
+    const auto& fn = second_fn(prog);
+    const auto& stmt = std::get<TyLetStmt>(fn.body->stmts[0]);
+    const auto& block = *std::get<TyBlockPtr>(stmt.init->node);
+    assert(block.ty == ty::num());
+    assert(is_ct_available(block));
+    assert(block.availability.kind == AvailabilityKind::Ct);
+}
+
 static void test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call() {
     must_fail_with_message(
         "runtime fn source() -> num { 1 }"
@@ -1570,6 +1582,7 @@ int main() {
     test_runtime_block_statement_taints_plain_result_function();
     test_runtime_statement_marks_unit_block_not_ct_available();
     test_unreachable_runtime_statement_does_not_taint_block();
+    test_resolved_block_tail_can_clear_runtime_projection();
     test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call();
     test_whole_term_runtime_work_accepts_runtime_result_contract();
     test_runtime_result_forwarded_param_does_not_count_as_hidden_work();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -121,7 +121,7 @@ static void test_unit_literal() {
 static void test_param_ref() {
     const auto prog = must_lower("fn f(x: num) -> num { x }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num());
+    assert(tail->ty == ty::num(true));
     assert(std::holds_alternative<LocalRef>(tail->node));
     assert(std::get<LocalRef>(tail->node).name == Symbol::intern("x"));
 }
@@ -170,7 +170,7 @@ static void test_arithmetic() {
              "fn f(x: num, y: num) -> num { x % y }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::num());
+        assert((*first_fn(prog).body->tail)->ty == ty::num(true));
     }
 }
 
@@ -186,7 +186,7 @@ static void test_comparisons() {
              "fn f(x: num, y: num) -> bool { x >= y }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
     }
 }
 
@@ -195,11 +195,11 @@ static void test_comparisons() {
 static void test_equality() {
     {
         const auto prog = must_lower("fn f(x: num, y: num) -> bool { x == y }");
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
     }
     {
         const auto prog = must_lower("fn f(x: bool, y: bool) -> bool { x != y }");
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
     }
 }
 
@@ -215,7 +215,7 @@ static void test_logical() {
              "fn f(a: bool, b: bool) -> bool { a || b }",
          }) {
         const auto prog = must_lower(src);
-        assert((*first_fn(prog).body->tail)->ty == ty::bool_());
+        assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
     }
 }
 
@@ -272,10 +272,10 @@ static void test_runtime_block_statement_taints_plain_result_function() {
 static void test_runtime_statement_marks_unit_block_not_ct_available() {
     const auto prog = must_lower("fn value(x: runtime num) { x; }");
     const auto& fn = first_fn(prog);
-    assert(fn.body->ty == ty::unit());
+    assert(fn.body->ty == ty::unit(true));
     assert(!is_ct_available(*fn.body));
     assert(fn.body->availability.kind == AvailabilityKind::Rt);
-    assert(!fn.body->availability.evidence.has_value());
+    assert(fn.body->availability.evidence.has_value());
 }
 
 static void test_unreachable_runtime_statement_does_not_taint_block() {
@@ -384,7 +384,7 @@ static void test_runtime_result_forwarded_param_does_not_count_as_hidden_work() 
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
     assert(!is_ct_available(*fn.body));
-    assert(!fn.body->availability.evidence.has_value());
+    assert(fn.body->availability.evidence.has_value());
 }
 
 static void test_generic_runtime_result_forwarded_param_does_not_count_as_hidden_work() {
@@ -394,7 +394,7 @@ static void test_generic_runtime_result_forwarded_param_does_not_count_as_hidden
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
     assert(!is_ct_available(*fn.body));
-    assert(!fn.body->availability.evidence.has_value());
+    assert(fn.body->availability.evidence.has_value());
 }
 
 static void test_plain_extern_call_accepts_runtime_argument_and_lifts_result() {
@@ -488,12 +488,12 @@ static void test_runtime_block_prevents_demotion() {
 
 static void test_unary_negate() {
     const auto prog = must_lower("fn f(x: num) -> num { -x }");
-    assert((*first_fn(prog).body->tail)->ty == ty::num());
+    assert((*first_fn(prog).body->tail)->ty == ty::num(true));
 }
 
 static void test_unary_not() {
     const auto prog = must_lower("fn f(b: bool) -> bool { !b }");
-    assert((*first_fn(prog).body->tail)->ty == ty::bool_());
+    assert((*first_fn(prog).body->tail)->ty == ty::bool_(true));
 }
 
 static void test_runtime_unary_negate_preserves_runtime_type() {
@@ -519,17 +519,17 @@ static void test_if_no_else() {
     // Without else: result type is Unit; if becomes the tail expression
     const auto prog = must_lower("fn f(b: bool) { if b { } }");
     const auto& body = *first_fn(prog).body;
-    assert(body.ty == ty::unit());
+    assert(body.ty == ty::unit(true));
     // Parser emits the if as the block's tail expression
     assert(body.tail.has_value());
-    assert((*body.tail)->ty == ty::unit());
+    assert((*body.tail)->ty == ty::unit(true));
     assert(std::holds_alternative<TyIf>((*body.tail)->node));
 }
 
 static void test_if_else() {
     const auto prog = must_lower("fn f(b: bool) -> num { if b { 1 } else { 2 } }");
     const auto& tail = *(*first_fn(prog).body->tail);
-    assert(tail.ty == ty::num());
+    assert(tail.ty == ty::num(true));
     assert(std::holds_alternative<TyIf>(tail.node));
 }
 
@@ -589,7 +589,7 @@ static void test_while() {
     assert(fn_body.tail.has_value());
     const auto& while_expr = *fn_body.tail;
     assert(std::holds_alternative<TyWhile>(while_expr->node));
-    assert(while_expr->ty == ty::unit());
+    assert(while_expr->ty == ty::unit(true));
 }
 
 static void test_runtime_while_condition_accepted() {
@@ -721,7 +721,7 @@ static void test_loop_multiple_breaks_same_type() {
         "  }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num());
+    assert(tail->ty == ty::num(true));
 }
 
 static void test_loop_break_type_mismatch_error() {
@@ -789,7 +789,7 @@ static void test_break_value_in_for_error() {
 static void test_bare_break_in_while_ok() {
     const auto prog = must_lower("fn f(b: bool) { while b { break; } }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::unit());
+    assert(tail->ty == ty::unit(true));
 }
 
 static void test_bare_break_in_for_ok() {
@@ -845,7 +845,7 @@ static void test_break_value_in_loop_nested_inside_while() {
         "  }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num());
+    assert(tail->ty == ty::num(true));
 }
 
 static void test_continue_in_while_ok() {
@@ -940,7 +940,7 @@ static void test_if_one_branch_diverges_other_unit() {
     // if b { return; } (no else) — if without else is always Unit
     const auto prog = must_lower("fn f(b: bool) { if b { return; } }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::unit());
+    assert(tail->ty == ty::unit(true));
 }
 
 static void test_if_else_one_branch_diverges() {
@@ -950,7 +950,7 @@ static void test_if_else_one_branch_diverges() {
         "  if b { return 1; } else { 42 }"
         "}");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num());
+    assert(tail->ty == ty::num(true));
 }
 
 static void test_if_diverging_then_does_not_leak_move_state() {
@@ -1101,7 +1101,7 @@ static void test_let_annotation_resolves_direct_deferred_call() {
         "fn f(flag: bool) { let x: num = make_default(flag); }");
     const auto& stmt = std::get<TyLetStmt>(second_fn(prog).body->stmts[0]);
     assert(stmt.ty == ty::num());
-    assert(stmt.init->ty == ty::num());
+    assert(stmt.init->ty == ty::num(true));
     const auto& call = std::get<TyCall>(stmt.init->node);
     assert(call.generic_args.size() == 1);
     assert(call.generic_args[0] == ty::num());
@@ -1115,7 +1115,7 @@ static void test_return_type_resolves_deferred_call_through_if_branches() {
     const auto& ret = std::get<TyReturn>(stmt.expr->node);
     assert(ret.value.has_value());
     const auto& if_expr = **ret.value;
-    assert(if_expr.ty == ty::num());
+    assert(if_expr.ty == ty::num(true));
     const auto& branch = std::get<TyIf>(if_expr.node);
     assert(branch.then_block->ty == ty::num());
     assert(branch.then_block->tail.has_value());
@@ -1443,10 +1443,12 @@ static void test_field_access() {
         "struct Point { x: num, y: num }"
         "fn get_x(p: Point) -> num { p.x }");
     const auto& tail = *first_fn(prog).body->tail;
-    assert(tail->ty == ty::num());
+    assert(tail->ty == ty::num(true));
     const auto& fa = std::get<TyFieldAccess>(tail->node);
     assert(fa.field == Symbol::intern("x"));
-    assert(fa.base->ty == ty::named(Symbol::intern("Point"), kInvalidSymbol, ValueSemantics::Copy));
+    assert(
+        fa.base->ty
+        == ty::named(Symbol::intern("Point"), kInvalidSymbol, ValueSemantics::Copy, true));
 }
 
 static void test_runtime_field_access_preserves_runtime_tag() {

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -1560,6 +1560,13 @@ static void test_runtime_field_decl_rejects_ct_required_use() {
         "argument `value` must be compile-time available");
 }
 
+static void test_runtime_field_decl_prevents_return_demotion() {
+    must_fail_with_message(
+        "struct Box { value: runtime num }"
+        "fn f() -> num { let box: Box = Box { value: 1 }; box.value }",
+        "runtime dependence not reflected in its return type: runtime field 'value'");
+}
+
 static void test_field_access_unknown_field_error() {
     must_fail(
         "struct Point { x: num }"
@@ -1810,6 +1817,7 @@ int main() {
     test_field_access();
     test_runtime_field_access_preserves_runtime_tag();
     test_runtime_field_decl_rejects_ct_required_use();
+    test_runtime_field_decl_prevents_return_demotion();
     test_field_access_unknown_field_error();
     test_borrow_local_binding();
     test_borrow_runtime_field_binding();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -274,7 +274,9 @@ static void test_runtime_statement_marks_unit_block_not_ct_available() {
     const auto& fn = first_fn(prog);
     assert(fn.body->ty == ty::unit());
     assert(!fn.body->ct_available);
+    assert(fn.body->availability.kind == AvailabilityKind::Rt);
     assert(!fn.body->runtime_evidence.has_value());
+    assert(!fn.body->availability.evidence.has_value());
 }
 
 static void test_unreachable_runtime_statement_does_not_taint_block() {
@@ -282,6 +284,7 @@ static void test_unreachable_runtime_statement_does_not_taint_block() {
     const auto& fn = first_fn(prog);
     assert(fn.body->ty == ty::never());
     assert(fn.body->ct_available);
+    assert(fn.body->availability.kind == AvailabilityKind::Ct);
     assert(!fn.body->runtime_evidence.has_value());
 }
 
@@ -301,6 +304,7 @@ static void test_whole_term_runtime_work_accepts_runtime_result_contract() {
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
     assert(!fn.body->ct_available);
+    assert(fn.body->availability.kind == AvailabilityKind::Rt);
 }
 
 static void test_runtime_function_accepts_whole_term_runtime_work() {
@@ -336,6 +340,7 @@ static void test_plain_call_lifts_runtime_arguments() {
     const auto& call = std::get<TyCall>(stmt.init->node);
     assert(stmt.ty == ty::num(true));
     assert(stmt.init->ty == ty::num(true));
+    assert(stmt.init->availability.kind == AvailabilityKind::Rt);
     assert(call.args[0]->ty == ty::num(true));
     assert(call.args[1]->ty == ty::num(true));
 }

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -273,9 +273,8 @@ static void test_runtime_statement_marks_unit_block_not_ct_available() {
     const auto prog = must_lower("fn value(x: runtime num) { x; }");
     const auto& fn = first_fn(prog);
     assert(fn.body->ty == ty::unit());
-    assert(!fn.body->ct_available);
+    assert(!is_ct_available(*fn.body));
     assert(fn.body->availability.kind == AvailabilityKind::Rt);
-    assert(!fn.body->runtime_evidence.has_value());
     assert(!fn.body->availability.evidence.has_value());
 }
 
@@ -283,9 +282,8 @@ static void test_unreachable_runtime_statement_does_not_taint_block() {
     const auto prog = must_lower("fn value() -> num { return 1; runtime { 0 }; }");
     const auto& fn = first_fn(prog);
     assert(fn.body->ty == ty::never());
-    assert(fn.body->ct_available);
+    assert(is_ct_available(*fn.body));
     assert(fn.body->availability.kind == AvailabilityKind::Ct);
-    assert(!fn.body->runtime_evidence.has_value());
 }
 
 static void test_plain_helper_rejects_hidden_runtime_work_for_ct_required_call() {
@@ -303,7 +301,7 @@ static void test_whole_term_runtime_work_accepts_runtime_result_contract() {
         "fn value() -> runtime num { source(); 1 }");
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
-    assert(!fn.body->ct_available);
+    assert(!is_ct_available(*fn.body));
     assert(fn.body->availability.kind == AvailabilityKind::Rt);
 }
 
@@ -314,10 +312,10 @@ static void test_runtime_function_accepts_whole_term_runtime_work() {
     const auto& source = first_fn(prog);
     const auto& fn = second_fn(prog);
     assert(source.body->ty == ty::num(true));
-    assert(!source.body->ct_available);
+    assert(!is_ct_available(*source.body));
     assert(fn.return_ty == ty::num(true));
     assert(fn.body->ty == ty::num(true));
-    assert(!fn.body->ct_available);
+    assert(!is_ct_available(*fn.body));
 }
 
 static void test_ordinarily_polymorphic_helper_still_accepts_runtime_arguments() {
@@ -385,8 +383,8 @@ static void test_runtime_result_forwarded_param_does_not_count_as_hidden_work() 
         "fn f(value: runtime num) -> runtime num { id(value) }");
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
-    assert(!fn.body->ct_available);
-    assert(!fn.body->runtime_evidence.has_value());
+    assert(!is_ct_available(*fn.body));
+    assert(!fn.body->availability.evidence.has_value());
 }
 
 static void test_generic_runtime_result_forwarded_param_does_not_count_as_hidden_work() {
@@ -395,8 +393,8 @@ static void test_generic_runtime_result_forwarded_param_does_not_count_as_hidden
         "fn f(value: runtime num) -> runtime num { id(value) }");
     const auto& fn = second_fn(prog);
     assert(fn.body->ty == ty::num(true));
-    assert(!fn.body->ct_available);
-    assert(!fn.body->runtime_evidence.has_value());
+    assert(!is_ct_available(*fn.body));
+    assert(!fn.body->availability.evidence.has_value());
 }
 
 static void test_plain_extern_call_accepts_runtime_argument_and_lifts_result() {
@@ -665,7 +663,7 @@ static void test_runtime_return_payload_marks_body_not_ct_available() {
     const auto prog = must_lower("fn f(x: runtime num) -> runtime num { return x; }");
     const auto& body = *first_fn(prog).body;
     assert(body.ty == ty::never());
-    assert(!body.ct_available);
+    assert(!is_ct_available(body));
 }
 
 static void test_runtime_break_payload_marks_loop_body_not_ct_available() {
@@ -673,8 +671,8 @@ static void test_runtime_break_payload_marks_loop_body_not_ct_available() {
     const auto& body = *first_fn(prog).body;
     const auto& loop = std::get<TyLoop>((*body.tail)->node);
     assert((*body.tail)->ty == ty::num(true));
-    assert(!body.ct_available);
-    assert(!loop.body->ct_available);
+    assert(!is_ct_available(body));
+    assert(!is_ct_available(*loop.body));
 }
 
 // ─── Loop/break type inference ────────────────────────────────────────────────

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -714,6 +714,7 @@ static void test_for_unreachable_step_does_not_taint_plain_result() {
     const auto prog = must_lower("fn f() -> num { for (;; runtime { 1 }) { break; }; 0 }");
     const auto& body = *first_fn(prog).body;
     assert(body.availability.kind == AvailabilityKind::Ct);
+    assert(body.availability.evidence == std::nullopt);
     assert(body.tail.has_value());
     assert((*body.tail)->ty == ty::num());
 }

--- a/compiler/cstc_tyir_interp/include/cstc_tyir_interp/detail.hpp
+++ b/compiler/cstc_tyir_interp/include/cstc_tyir_interp/detail.hpp
@@ -77,6 +77,7 @@ struct EvalContext {
     std::size_t remaining_call_depth = kDefaultEvalCallDepth;
     std::unordered_set<Symbol, SymbolHash> generic_params;
     std::shared_ptr<struct ConstraintEvalState> constraint_state;
+    bool enforce_runtime_barriers = true;
 };
 
 struct ConstraintEvalState {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -1376,7 +1376,8 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     rewritten.generic_args.push_back(apply_substitution(generic_arg, subst));
                 for (tyir::TyExprPtr& arg : rewritten.args)
                     arg = apply_substitution(arg, subst);
-                return tyir::make_ty_expr(expr->span, std::move(rewritten), rewritten_ty);
+                return tyir::make_ty_expr(
+                    expr->span, std::move(rewritten), rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyDeclProbe>) {
                 tyir::TyDeclProbe rewritten = node;
                 if (rewritten.expr.has_value())
@@ -1398,7 +1399,8 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                 for (tyir::TyExprPtr& arg : rewritten.args)
                     arg = apply_substitution(arg, subst);
                 if (!fully_resolved)
-                    return tyir::make_ty_expr(expr->span, std::move(rewritten), rewritten_ty);
+                    return tyir::make_ty_expr(
+                        expr->span, std::move(rewritten), rewritten_ty, expr->availability);
 
                 std::vector<tyir::Ty> concrete_generic_args;
                 concrete_generic_args.reserve(rewritten.generic_args.size());
@@ -1411,7 +1413,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     tyir::TyCall{
                         rewritten.fn_name, std::move(concrete_generic_args),
                         std::move(rewritten.args)},
-                    rewritten_ty);
+                    rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
                 return tyir::make_ty_expr(
                     expr->span, tyir::TyRuntimeBlock{apply_substitution(node.body, subst)},
@@ -3524,7 +3526,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                 return maybe_fold_constant(
                     tyir::make_ty_expr(
                         expr->span, tyir::TyCall{node.fn_name, node.generic_args, std::move(args)},
-                        expr->ty),
+                        expr->ty, expr->availability),
                     program, env, generic_params);
             }
 
@@ -3555,7 +3557,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyDeferredGenericCall{node.fn_name, node.generic_args, std::move(args)},
-                    expr->ty);
+                    expr->ty, expr->availability);
             }
 
             if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -258,9 +258,8 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
     return tyir::is_ct_available(expr);
 }
 
-[[nodiscard]] static bool has_concrete_runtime_barrier(const tyir::TyExpr& expr) {
-    return expr.availability.kind == tyir::AvailabilityKind::Rt
-        && expr.availability.evidence.has_value();
+[[nodiscard]] static bool has_runtime_barrier(const tyir::TyExpr& expr) {
+    return expr.availability.kind == tyir::AvailabilityKind::Rt;
 }
 
 [[nodiscard]] static bool stmt_can_fallthrough(const tyir::TyStmt& stmt);
@@ -1183,6 +1182,98 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
 [[nodiscard]] static bool expr_depends_on_generic_params(
     const tyir::TyExprPtr& expr, const GenericParamSet& generic_params);
 
+[[nodiscard]] static bool expr_contains_local_ref(const tyir::TyExprPtr& expr);
+
+[[nodiscard]] static bool block_contains_local_ref(const tyir::TyBlockPtr& block) {
+    if (block == nullptr)
+        return false;
+    for (const tyir::TyStmt& stmt : block->stmts) {
+        const bool contains = std::visit(
+            [&](const auto& node) {
+                using Node = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<Node, tyir::TyLetStmt>) {
+                    return expr_contains_local_ref(node.init);
+                } else {
+                    return expr_contains_local_ref(node.expr);
+                }
+            },
+            stmt);
+        if (contains)
+            return true;
+    }
+    return block->tail.has_value() && expr_contains_local_ref(*block->tail);
+}
+
+[[nodiscard]] static bool expr_contains_local_ref(const tyir::TyExprPtr& expr) {
+    if (expr == nullptr)
+        return false;
+    return std::visit(
+        [&](const auto& node) {
+            using Node = std::decay_t<decltype(node)>;
+            if constexpr (std::is_same_v<Node, tyir::LocalRef>) {
+                return true;
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyLiteral> || std::is_same_v<Node, tyir::EnumVariantRef>
+                || std::is_same_v<Node, tyir::TyContinue>) {
+                return false;
+            } else if constexpr (std::is_same_v<Node, tyir::TyStructInit>) {
+                for (const tyir::TyStructInitField& field : node.fields) {
+                    if (expr_contains_local_ref(field.value))
+                        return true;
+                }
+                return false;
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyBorrow> || std::is_same_v<Node, tyir::TyUnary>) {
+                return expr_contains_local_ref(node.rhs);
+            } else if constexpr (std::is_same_v<Node, tyir::TyBinary>) {
+                return expr_contains_local_ref(node.lhs) || expr_contains_local_ref(node.rhs);
+            } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
+                return expr_contains_local_ref(node.base);
+            } else if constexpr (std::is_same_v<Node, tyir::TyCall>) {
+                for (const tyir::TyExprPtr& arg : node.args) {
+                    if (expr_contains_local_ref(arg))
+                        return true;
+                }
+                return false;
+            } else if constexpr (std::is_same_v<Node, tyir::TyDeclProbe>) {
+                return node.expr.has_value() && expr_contains_local_ref(*node.expr);
+            } else if constexpr (std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
+                for (const tyir::TyExprPtr& arg : node.args) {
+                    if (expr_contains_local_ref(arg))
+                        return true;
+                }
+                return false;
+            } else if constexpr (std::is_same_v<Node, tyir::TyBlockPtr>) {
+                return block_contains_local_ref(node);
+            } else if constexpr (std::is_same_v<Node, tyir::TyIf>) {
+                if (expr_contains_local_ref(node.condition)
+                    || block_contains_local_ref(node.then_block)) {
+                    return true;
+                }
+                return node.else_branch.has_value() && expr_contains_local_ref(*node.else_branch);
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyRuntimeBlock> || std::is_same_v<Node, tyir::TyLoop>) {
+                return block_contains_local_ref(node.body);
+            } else if constexpr (std::is_same_v<Node, tyir::TyWhile>) {
+                return expr_contains_local_ref(node.condition)
+                    || block_contains_local_ref(node.body);
+            } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
+                if (node.init.has_value() && expr_contains_local_ref(node.init->init))
+                    return true;
+                if (node.condition.has_value() && expr_contains_local_ref(*node.condition))
+                    return true;
+                if (node.step.has_value() && expr_contains_local_ref(*node.step))
+                    return true;
+                return block_contains_local_ref(node.body);
+            } else {
+                static_assert(
+                    std::is_same_v<Node, tyir::TyBreak> || std::is_same_v<Node, tyir::TyReturn>);
+                return node.value.has_value() && expr_contains_local_ref(*node.value);
+            }
+        },
+        expr->node);
+}
+
 [[nodiscard]] static bool block_depends_on_generic_params(
     const tyir::TyBlockPtr& block, const GenericParamSet& generic_params) {
     if (block == nullptr)
@@ -1756,7 +1847,7 @@ ConstraintEvalResult evaluate_constraint(
                 ConstraintEvalKind::Unsatisfied, "probed expression is not type-valid",
                 std::nullopt};
         }
-        if (has_concrete_runtime_barrier(*expr)) {
+        if (has_runtime_barrier(*expr) && !expr_contains_local_ref(expr)) {
             return {
                 ConstraintEvalKind::Unsatisfied,
                 "probed expression uses runtime-only behavior",
@@ -2520,7 +2611,7 @@ std::expected<ValuePtr, EvalError> eval_lang_intrinsic(
 
 [[nodiscard]] static std::expected<EvalState, EvalError>
     eval_expr(const tyir::TyExprPtr& expr, ConstEnv& env, EvalContext& ctx) {
-    if (has_concrete_runtime_barrier(*expr))
+    if (ctx.enforce_runtime_barriers && has_runtime_barrier(*expr))
         return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
 
     return std::visit(
@@ -2785,7 +2876,10 @@ std::expected<ValuePtr, EvalError> eval_lang_intrinsic(
                     if (!call_budget)
                         return std::unexpected(std::move(call_budget.error()));
                     ctx.stack.push_back(EvalStackFrame{fn.name, expr->span});
+                    const bool was_enforcing_runtime_barriers = ctx.enforce_runtime_barriers;
+                    ctx.enforce_runtime_barriers = false;
                     auto result = eval_block(fn.body, fn_env, ctx);
+                    ctx.enforce_runtime_barriers = was_enforcing_runtime_barriers;
                     ctx.stack.pop_back();
                     ++ctx.remaining_call_depth;
                     if (!result)
@@ -3425,6 +3519,8 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
 [[nodiscard]] static std::expected<tyir::TyExprPtr, EvalError> maybe_fold_constant(
     const tyir::TyExprPtr& expr, const ProgramView& program, const ConstEnv& env,
     const GenericParamSet& generic_params) {
+    tyir::TyExprPtr candidate = std::make_shared<tyir::TyExpr>(*expr);
+    recompute_expr_availability(*candidate);
     ConstEnv eval_env = env;
     EvalContext ctx{
         program,
@@ -3435,16 +3531,17 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
         std::make_shared<ConstraintEvalState>(),
     };
     ctx.generic_params = generic_params;
-    auto value = eval_expr(expr, eval_env, ctx);
+    auto value = eval_expr(candidate, eval_env, ctx);
     if (!value)
         return std::unexpected(std::move(value.error()));
     if (value->kind != EvalState::Kind::Value)
-        return expr;
-    if (!can_fold_reference_expr(expr->ty, value->value))
-        return expr;
+        return candidate;
+    if (!can_fold_reference_expr(candidate->ty, value->value))
+        return candidate;
     auto folded = value_to_expr(
         program, value->value,
-        tyir::with_availability_projection(expr->ty, tyir::availability_ct()), expr->span);
+        tyir::with_availability_projection(candidate->ty, tyir::availability_ct()),
+        candidate->span);
     if (!folded)
         return std::unexpected(std::move(folded.error()));
     return *folded;
@@ -3621,8 +3718,11 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                             return std::unexpected(std::move(then_block.error()));
                         auto then_ptr = std::make_shared<tyir::TyBlock>(std::move(*then_block));
                         return maybe_fold_constant(
-                            tyir::make_ty_expr(expr->span, then_ptr, expr->ty), program, env,
-                            generic_params);
+                            tyir::make_ty_expr(
+                                expr->span, then_ptr,
+                                tyir::with_availability_projection(
+                                    expr->ty, then_ptr->availability)),
+                            program, env, generic_params);
                     }
                     if (node.else_branch.has_value())
                         return fold_expr(*node.else_branch, branch_env, program, generic_params);

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -1158,9 +1158,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
     auto rewritten = std::make_shared<tyir::TyBlock>();
     rewritten->ty = apply_substitution(block->ty, subst);
     rewritten->span = block->span;
-    tyir::set_availability(
-        *rewritten, tyir::availability_from_legacy(
-                        rewritten->ty, block->span, block->ct_available, block->runtime_evidence));
+    tyir::set_availability(*rewritten, block->availability);
     rewritten->stmts.reserve(block->stmts.size());
     for (const tyir::TyStmt& stmt : block->stmts) {
         rewritten->stmts.push_back(
@@ -1331,9 +1329,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
             }
         },
         expr->node);
-    tyir::set_availability(
-        *rewritten_expr, tyir::availability_from_legacy(
-                             rewritten_ty, expr->span, expr->ct_available, expr->runtime_evidence));
+    tyir::set_availability(*rewritten_expr, expr->availability);
     return rewritten_expr;
 }
 
@@ -3628,10 +3624,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
         },
         expr->node);
     if (folded.has_value() && *folded != nullptr) {
-        tyir::set_availability(
-            **folded,
-            tyir::availability_from_legacy(
-                (*folded)->ty, (*folded)->span, expr->ct_available, expr->runtime_evidence));
+        tyir::set_availability(**folded, expr->availability);
     }
     return folded;
 }

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -2070,6 +2070,44 @@ ConstraintEvalResult evaluate_constraint(
                         return lhs;
                     return self(self, node.rhs);
                 } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
+                    if (node.base == nullptr || node.base->ty.kind != tyir::TyKind::Named) {
+                        return {
+                            ConstraintEvalKind::Unsatisfied,
+                            "probed expression is not type-valid",
+                            std::nullopt,
+                        };
+                    }
+                    const auto decl_it = program.structs.find(node.base->ty.name);
+                    if (decl_it == program.structs.end()) {
+                        return {
+                            ConstraintEvalKind::Unsatisfied,
+                            "probed expression is not type-valid",
+                            std::nullopt,
+                        };
+                    }
+                    const auto field_it = std::find_if(
+                        decl_it->second->fields.begin(), decl_it->second->fields.end(),
+                        [&](const tyir::TyFieldDecl& field) { return field.name == node.field; });
+                    if (field_it == decl_it->second->fields.end()) {
+                        return {
+                            ConstraintEvalKind::Unsatisfied,
+                            "probed expression is not type-valid",
+                            std::nullopt,
+                        };
+                    }
+                    tyir::Ty field_ty = field_it->ty;
+                    if (!node.base->ty.generic_args.empty()) {
+                        const auto substitution = build_substitution(
+                            decl_it->second->generic_params, node.base->ty.generic_args);
+                        field_ty = apply_substitution(field_ty, substitution);
+                    }
+                    if (tyir::ty_contains_runtime_tag(field_ty)) {
+                        return {
+                            ConstraintEvalKind::Unsatisfied,
+                            "probed expression uses runtime-only behavior",
+                            std::nullopt,
+                        };
+                    }
                     return self(self, node.base);
                 } else if constexpr (std::is_same_v<Node, tyir::TyCall>) {
                     bool defer_where_clause = false;
@@ -2292,6 +2330,13 @@ ConstraintEvalResult evaluate_constraint(
                 } else if constexpr (
                     std::is_same_v<Node, tyir::TyRuntimeBlock>
                     || std::is_same_v<Node, tyir::TyLoop>) {
+                    if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
+                        return {
+                            ConstraintEvalKind::Unsatisfied,
+                            "probed expression uses runtime-only behavior",
+                            std::nullopt,
+                        };
+                    }
                     if (node.body == nullptr)
                         return {ConstraintEvalKind::Satisfied, {}, std::nullopt};
                     return self(self, tyir::make_ty_expr(expr->span, node.body, node.body->ty));

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -368,19 +368,22 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
             } else if constexpr (std::is_same_v<Node, tyir::TyIf>) {
                 availability =
                     tyir::availability_join(availability, availability_of_expr(node.condition));
-                availability =
-                    tyir::availability_join(availability, availability_of_block(node.then_block));
-                if (node.else_branch.has_value())
+                if (node.condition != nullptr && expr_can_fallthrough(*node.condition)) {
                     availability = tyir::availability_join(
-                        availability, availability_of_expr(*node.else_branch));
+                        availability, availability_of_block(node.then_block));
+                    if (node.else_branch.has_value())
+                        availability = tyir::availability_join(
+                            availability, availability_of_expr(*node.else_branch));
+                }
             } else if constexpr (std::is_same_v<Node, tyir::TyLoop>) {
                 availability =
                     tyir::availability_join(availability, availability_of_block(node.body));
             } else if constexpr (std::is_same_v<Node, tyir::TyWhile>) {
                 availability =
                     tyir::availability_join(availability, availability_of_expr(node.condition));
-                availability =
-                    tyir::availability_join(availability, availability_of_block(node.body));
+                if (node.condition != nullptr && expr_can_fallthrough(*node.condition))
+                    availability =
+                        tyir::availability_join(availability, availability_of_block(node.body));
             } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
                 bool reachable = true;
                 if (node.init.has_value() && reachable) {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -2262,12 +2262,9 @@ ConstraintEvalResult evaluate_constraint(
                             [&](const auto& stmt_node) -> ConstraintEvalResult {
                                 using StmtNode = std::decay_t<decltype(stmt_node)>;
                                 if constexpr (std::is_same_v<StmtNode, tyir::TyLetStmt>) {
-                                    if (!call_argument_compatible(
-                                            stmt_node.init->ty, stmt_node.ty)) {
-                                        if (auto unresolved =
-                                                unresolved_call_argument_compatibility_check(
-                                                    stmt_node.init->ty, stmt_node.ty,
-                                                    generic_params);
+                                    if (!compatible(stmt_node.init->ty, stmt_node.ty)) {
+                                        if (auto unresolved = unresolved_compatibility_check(
+                                                stmt_node.init->ty, stmt_node.ty, generic_params);
                                             unresolved.has_value()) {
                                             return *unresolved;
                                         }
@@ -2359,8 +2356,8 @@ ConstraintEvalResult evaluate_constraint(
                     return self(self, tyir::make_ty_expr(expr->span, node.body, node.body->ty));
                 } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
                     if (node.init.has_value()) {
-                        if (!call_argument_compatible(node.init->init->ty, node.init->ty)) {
-                            if (auto unresolved = unresolved_call_argument_compatibility_check(
+                        if (!compatible(node.init->init->ty, node.init->ty)) {
+                            if (auto unresolved = unresolved_compatibility_check(
                                     node.init->init->ty, node.init->ty, generic_params);
                                 unresolved.has_value()) {
                                 return *unresolved;

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -343,6 +343,7 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
             } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
                 availability =
                     tyir::availability_join(availability, availability_of_expr(node.base));
+                availability = tyir::availability_join(availability, expr.availability);
             } else if constexpr (
                 std::is_same_v<Node, tyir::TyCall>
                 || std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
@@ -1485,7 +1486,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     expr->span,
                     tyir::TyFieldAccess{
                         apply_substitution(node.base, subst), node.field, node.use_kind},
-                    rewritten_ty);
+                    rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyCall>) {
                 tyir::TyCall rewritten = node;
                 rewritten.generic_args.clear();
@@ -3629,8 +3630,8 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                     return std::unexpected(std::move(base.error()));
                 return maybe_fold_constant(
                     tyir::make_ty_expr(
-                        expr->span, tyir::TyFieldAccess{*base, node.field, node.use_kind},
-                        expr->ty),
+                        expr->span, tyir::TyFieldAccess{*base, node.field, node.use_kind}, expr->ty,
+                        expr->availability),
                     program, env, generic_params);
             }
 

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -264,6 +264,147 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
         && (expr.availability.evidence.has_value() || type_has_runtime_dependency(expr.ty));
 }
 
+[[nodiscard]] static bool stmt_can_fallthrough(const tyir::TyStmt& stmt);
+
+[[nodiscard]] static tyir::Availability availability_of_expr(const tyir::TyExprPtr& expr) {
+    return expr != nullptr ? expr->availability : tyir::availability_ct();
+}
+
+[[nodiscard]] static tyir::Availability availability_of_block(const tyir::TyBlockPtr& block) {
+    return block != nullptr ? block->availability : tyir::availability_ct();
+}
+
+[[nodiscard]] static tyir::Availability runtime_block_availability(SourceSpan span) {
+    return tyir::availability_rt(tyir::TyRuntimeEvidence{span, "runtime block"});
+}
+
+[[nodiscard]] static tyir::Availability stmt_availability(const tyir::TyStmt& stmt) {
+    return std::visit(
+        [&](const auto& node) -> tyir::Availability {
+            using Node = std::decay_t<decltype(node)>;
+            if constexpr (std::is_same_v<Node, tyir::TyLetStmt>) {
+                return availability_of_expr(node.init);
+            } else {
+                tyir::Availability availability = availability_of_expr(node.expr);
+                if (node.expr == nullptr)
+                    return availability;
+
+                return std::visit(
+                    [&](const auto& expr_node) -> tyir::Availability {
+                        using ExprNode = std::decay_t<decltype(expr_node)>;
+                        if constexpr (
+                            std::is_same_v<ExprNode, tyir::TyBreak>
+                            || std::is_same_v<ExprNode, tyir::TyReturn>) {
+                            if (expr_node.value.has_value()) {
+                                return tyir::availability_join(
+                                    availability, availability_of_expr(*expr_node.value));
+                            }
+                        }
+                        return availability;
+                    },
+                    node.expr->node);
+            }
+        },
+        stmt);
+}
+
+static void recompute_expr_availability(tyir::TyExpr& expr) {
+    tyir::Availability availability = tyir::availability_from_type(expr.ty, expr.span);
+
+    std::visit(
+        [&](const auto& node) {
+            using Node = std::decay_t<decltype(node)>;
+            if constexpr (
+                std::is_same_v<Node, tyir::TyLiteral> || std::is_same_v<Node, tyir::LocalRef>
+                || std::is_same_v<Node, tyir::EnumVariantRef>
+                || std::is_same_v<Node, tyir::TyContinue>) {
+                availability = tyir::availability_join(availability, expr.availability);
+            } else if constexpr (std::is_same_v<Node, tyir::TyStructInit>) {
+                for (const tyir::TyStructInitField& field : node.fields)
+                    availability =
+                        tyir::availability_join(availability, availability_of_expr(field.value));
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyBorrow> || std::is_same_v<Node, tyir::TyUnary>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.rhs));
+            } else if constexpr (std::is_same_v<Node, tyir::TyBinary>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.lhs));
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.rhs));
+            } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.base));
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyCall>
+                || std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
+                for (const tyir::TyExprPtr& arg : node.args)
+                    availability = tyir::availability_join(availability, availability_of_expr(arg));
+            } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
+                availability =
+                    tyir::availability_join(availability, runtime_block_availability(expr.span));
+                availability =
+                    tyir::availability_join(availability, availability_of_block(node.body));
+            } else if constexpr (std::is_same_v<Node, tyir::TyBlockPtr>) {
+                availability = tyir::availability_join(availability, availability_of_block(node));
+            } else if constexpr (std::is_same_v<Node, tyir::TyIf>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.condition));
+                availability =
+                    tyir::availability_join(availability, availability_of_block(node.then_block));
+                if (node.else_branch.has_value())
+                    availability = tyir::availability_join(
+                        availability, availability_of_expr(*node.else_branch));
+            } else if constexpr (std::is_same_v<Node, tyir::TyLoop>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_block(node.body));
+            } else if constexpr (std::is_same_v<Node, tyir::TyWhile>) {
+                availability =
+                    tyir::availability_join(availability, availability_of_expr(node.condition));
+                availability =
+                    tyir::availability_join(availability, availability_of_block(node.body));
+            } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
+                if (node.init.has_value())
+                    availability = tyir::availability_join(
+                        availability, availability_of_expr(node.init->init));
+                if (node.condition.has_value())
+                    availability = tyir::availability_join(
+                        availability, availability_of_expr(*node.condition));
+                if (node.step.has_value())
+                    availability =
+                        tyir::availability_join(availability, availability_of_expr(*node.step));
+                availability =
+                    tyir::availability_join(availability, availability_of_block(node.body));
+            } else if constexpr (
+                std::is_same_v<Node, tyir::TyBreak> || std::is_same_v<Node, tyir::TyReturn>) {
+                if (node.value.has_value())
+                    availability =
+                        tyir::availability_join(availability, availability_of_expr(*node.value));
+            }
+        },
+        expr.node);
+
+    tyir::set_availability(expr, availability);
+}
+
+static void recompute_block_availability(tyir::TyBlock& block) {
+    bool reachable = true;
+    tyir::Availability availability = tyir::availability_from_type(block.ty, block.span);
+
+    for (const tyir::TyStmt& stmt : block.stmts) {
+        if (!reachable)
+            break;
+
+        availability = tyir::availability_join(availability, stmt_availability(stmt));
+        reachable = stmt_can_fallthrough(stmt);
+    }
+
+    if (reachable && block.tail.has_value())
+        availability = tyir::availability_join(availability, availability_of_expr(*block.tail));
+
+    tyir::set_availability(block, availability);
+}
+
 [[nodiscard]] static bool call_argument_may_be_compatible_after_substitution(
     const tyir::Ty& actual, const tyir::Ty& expected, const GenericParamSet& generic_params) {
     return types_may_be_compatible_after_substitution(
@@ -1158,7 +1299,6 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
     auto rewritten = std::make_shared<tyir::TyBlock>();
     rewritten->ty = apply_substitution(block->ty, subst);
     rewritten->span = block->span;
-    tyir::set_availability(*rewritten, block->availability);
     rewritten->stmts.reserve(block->stmts.size());
     for (const tyir::TyStmt& stmt : block->stmts) {
         rewritten->stmts.push_back(
@@ -1181,6 +1321,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
     }
     if (block->tail.has_value())
         rewritten->tail = apply_substitution(*block->tail, subst);
+    recompute_block_availability(*rewritten);
     return rewritten;
 }
 
@@ -1197,7 +1338,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                 std::is_same_v<Node, tyir::TyLiteral> || std::is_same_v<Node, tyir::LocalRef>
                 || std::is_same_v<Node, tyir::EnumVariantRef>
                 || std::is_same_v<Node, tyir::TyContinue>) {
-                return tyir::make_ty_expr(expr->span, node, rewritten_ty);
+                return tyir::make_ty_expr(expr->span, node, rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyStructInit>) {
                 tyir::TyStructInit rewritten = node;
                 rewritten.generic_args.clear();
@@ -1329,7 +1470,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
             }
         },
         expr->node);
-    tyir::set_availability(*rewritten_expr, expr->availability);
+    recompute_expr_availability(*rewritten_expr);
     return rewritten_expr;
 }
 
@@ -3183,7 +3324,6 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
     tyir::TyBlock folded;
     folded.ty = block.ty;
     folded.span = block.span;
-    tyir::set_availability(folded, block.availability);
 
     for (std::size_t index = 0; index < block.stmts.size(); ++index) {
         const tyir::TyStmt& stmt = block.stmts[index];
@@ -3235,6 +3375,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                 block.stmts.end());
             folded.tail = block.tail;
             env.pop();
+            recompute_block_availability(folded);
             return folded;
         }
     }
@@ -3249,6 +3390,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
     }
 
     env.pop();
+    recompute_block_availability(folded);
     return folded;
 }
 
@@ -3288,6 +3430,8 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
             if constexpr (
                 std::is_same_v<Node, tyir::TyLiteral> || std::is_same_v<Node, tyir::LocalRef>
                 || std::is_same_v<Node, tyir::EnumVariantRef>) {
+                if (!tyir::is_ct_available(expr))
+                    return expr;
                 return maybe_fold_constant(expr, program, env, generic_params);
             }
 
@@ -3623,9 +3767,8 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
             return expr;
         },
         expr->node);
-    if (folded.has_value() && *folded != nullptr) {
-        tyir::set_availability(**folded, expr->availability);
-    }
+    if (folded.has_value() && *folded != nullptr)
+        recompute_expr_availability(**folded);
     return folded;
 }
 

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -256,7 +256,12 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 }
 
 [[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
-    return expr != nullptr && expr->ct_available && !type_has_runtime_dependency(expr->ty);
+    return tyir::is_ct_available(expr);
+}
+
+[[nodiscard]] static bool has_concrete_runtime_barrier(const tyir::TyExpr& expr) {
+    return expr.availability.kind == tyir::AvailabilityKind::Rt
+        && (expr.availability.evidence.has_value() || type_has_runtime_dependency(expr.ty));
 }
 
 [[nodiscard]] static bool call_argument_may_be_compatible_after_substitution(
@@ -1153,7 +1158,9 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
     auto rewritten = std::make_shared<tyir::TyBlock>();
     rewritten->ty = apply_substitution(block->ty, subst);
     rewritten->span = block->span;
-    rewritten->ct_available = block->ct_available && !type_has_runtime_dependency(rewritten->ty);
+    tyir::set_availability(
+        *rewritten, tyir::availability_from_legacy(
+                        rewritten->ty, block->span, block->ct_available, block->runtime_evidence));
     rewritten->stmts.reserve(block->stmts.size());
     for (const tyir::TyStmt& stmt : block->stmts) {
         rewritten->stmts.push_back(
@@ -1324,7 +1331,9 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
             }
         },
         expr->node);
-    rewritten_expr->ct_available = expr->ct_available && !type_has_runtime_dependency(rewritten_ty);
+    tyir::set_availability(
+        *rewritten_expr, tyir::availability_from_legacy(
+                             rewritten_ty, expr->span, expr->ct_available, expr->runtime_evidence));
     return rewritten_expr;
 }
 
@@ -1581,7 +1590,7 @@ ConstraintEvalResult evaluate_constraint(
                 ConstraintEvalKind::Unsatisfied, "probed expression is not type-valid",
                 std::nullopt};
         }
-        if (expr->ty.is_runtime && !std::holds_alternative<tyir::TyRuntimeBlock>(expr->node)) {
+        if (has_concrete_runtime_barrier(*expr)) {
             return {
                 ConstraintEvalKind::Unsatisfied,
                 "probed expression uses runtime-only behavior",
@@ -2342,7 +2351,7 @@ std::expected<ValuePtr, EvalError> eval_lang_intrinsic(
 
 [[nodiscard]] static std::expected<EvalState, EvalError>
     eval_expr(const tyir::TyExprPtr& expr, ConstEnv& env, EvalContext& ctx) {
-    if (expr->ty.is_runtime && !std::holds_alternative<tyir::TyRuntimeBlock>(expr->node))
+    if (has_concrete_runtime_barrier(*expr))
         return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
 
     return std::visit(
@@ -3178,6 +3187,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
     tyir::TyBlock folded;
     folded.ty = block.ty;
     folded.span = block.span;
+    tyir::set_availability(folded, block.availability);
 
     for (std::size_t index = 0; index < block.stmts.size(); ++index) {
         const tyir::TyStmt& stmt = block.stmts[index];
@@ -3275,7 +3285,7 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
 [[nodiscard]] static std::expected<tyir::TyExprPtr, EvalError> fold_expr(
     const tyir::TyExprPtr& expr, ConstEnv& env, const ProgramView& program,
     const GenericParamSet& generic_params) {
-    return std::visit(
+    auto folded = std::visit(
         [&](const auto& node) -> std::expected<tyir::TyExprPtr, EvalError> {
             using Node = std::decay_t<decltype(node)>;
 
@@ -3617,6 +3627,13 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
             return expr;
         },
         expr->node);
+    if (folded.has_value() && *folded != nullptr) {
+        tyir::set_availability(
+            **folded,
+            tyir::availability_from_legacy(
+                (*folded)->ty, (*folded)->span, expr->ct_available, expr->runtime_evidence));
+    }
+    return folded;
 }
 
 [[nodiscard]] static std::expected<void, EvalError> validate_constraints_in_expr(

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -254,8 +254,8 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
     return compatible(erase_runtime_qualifiers(actual), erase_runtime_qualifiers(expected));
 }
 
-[[nodiscard]] static bool expr_value_is_ct_available(const tyir::TyExprPtr& expr) {
-    return tyir::is_ct_available(expr);
+[[nodiscard]] static bool expr_value_satisfies_ct_requirement(const tyir::TyExprPtr& expr) {
+    return expr != nullptr && tyir::is_ct_required_available(expr->availability);
 }
 
 [[nodiscard]] static bool has_runtime_barrier(const tyir::TyExpr& expr) {
@@ -2116,7 +2116,7 @@ ConstraintEvalResult evaluate_constraint(
                                 };
                             }
                             if (fn.params[index].requires_ct()
-                                && !expr_value_is_ct_available(node.args[index])) {
+                                && !expr_value_satisfies_ct_requirement(node.args[index])) {
                                 return {
                                     ConstraintEvalKind::Unsatisfied,
                                     "probed expression is not type-valid",
@@ -2177,7 +2177,7 @@ ConstraintEvalResult evaluate_constraint(
                                 };
                             }
                             if (decl.params[index].requires_ct()
-                                && !expr_value_is_ct_available(node.args[index])) {
+                                && !expr_value_satisfies_ct_requirement(node.args[index])) {
                                 return {
                                     ConstraintEvalKind::Unsatisfied,
                                     "probed expression is not type-valid",

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -12,7 +12,6 @@ namespace cstc::tyir_interp::detail {
 using tyir::common_type;
 using tyir::compatible;
 using tyir::matches_type_shape;
-using tyir::type_has_runtime_dependency;
 
 ValuePtr make_num(double value) {
     auto out = std::make_shared<Value>();
@@ -261,7 +260,7 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 
 [[nodiscard]] static bool has_concrete_runtime_barrier(const tyir::TyExpr& expr) {
     return expr.availability.kind == tyir::AvailabilityKind::Rt
-        && (expr.availability.evidence.has_value() || type_has_runtime_dependency(expr.ty));
+        && expr.availability.evidence.has_value();
 }
 
 [[nodiscard]] static bool stmt_can_fallthrough(const tyir::TyStmt& stmt);
@@ -309,7 +308,7 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 }
 
 static void recompute_expr_availability(tyir::TyExpr& expr) {
-    tyir::Availability availability = tyir::availability_from_type(expr.ty, expr.span);
+    tyir::Availability availability = tyir::availability_ct();
 
     std::visit(
         [&](const auto& node) {
@@ -338,6 +337,7 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
             } else if constexpr (
                 std::is_same_v<Node, tyir::TyCall>
                 || std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
+                availability = tyir::availability_join(availability, expr.availability);
                 for (const tyir::TyExprPtr& arg : node.args)
                     availability = tyir::availability_join(availability, availability_of_expr(arg));
             } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
@@ -389,7 +389,7 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
 
 static void recompute_block_availability(tyir::TyBlock& block) {
     bool reachable = true;
-    tyir::Availability availability = tyir::availability_from_type(block.ty, block.span);
+    tyir::Availability availability = tyir::availability_ct();
 
     for (const tyir::TyStmt& stmt : block.stmts) {
         if (!reachable)
@@ -2099,9 +2099,12 @@ ConstraintEvalResult evaluate_constraint(
                             [&](const auto& stmt_node) -> ConstraintEvalResult {
                                 using StmtNode = std::decay_t<decltype(stmt_node)>;
                                 if constexpr (std::is_same_v<StmtNode, tyir::TyLetStmt>) {
-                                    if (!compatible(stmt_node.init->ty, stmt_node.ty)) {
-                                        if (auto unresolved = unresolved_compatibility_check(
-                                                stmt_node.init->ty, stmt_node.ty, generic_params);
+                                    if (!call_argument_compatible(
+                                            stmt_node.init->ty, stmt_node.ty)) {
+                                        if (auto unresolved =
+                                                unresolved_call_argument_compatibility_check(
+                                                    stmt_node.init->ty, stmt_node.ty,
+                                                    generic_params);
                                             unresolved.has_value()) {
                                             return *unresolved;
                                         }
@@ -2184,8 +2187,8 @@ ConstraintEvalResult evaluate_constraint(
                     return self(self, tyir::make_ty_expr(expr->span, node.body, node.body->ty));
                 } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
                     if (node.init.has_value()) {
-                        if (!compatible(node.init->init->ty, node.init->ty)) {
-                            if (auto unresolved = unresolved_compatibility_check(
+                        if (!call_argument_compatible(node.init->init->ty, node.init->ty)) {
+                            if (auto unresolved = unresolved_call_argument_compatibility_check(
                                     node.init->init->ty, node.init->ty, generic_params);
                                 unresolved.has_value()) {
                                 return *unresolved;
@@ -3414,7 +3417,9 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
         return expr;
     if (!can_fold_reference_expr(expr->ty, value->value))
         return expr;
-    auto folded = value_to_expr(program, value->value, expr->ty, expr->span);
+    auto folded = value_to_expr(
+        program, value->value,
+        tyir::with_availability_projection(expr->ty, tyir::availability_ct()), expr->span);
     if (!folded)
         return std::unexpected(std::move(folded.error()));
     return *folded;

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -323,9 +323,14 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
                 || std::is_same_v<Node, tyir::TyContinue>) {
                 availability = tyir::availability_join(availability, expr.availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyStructInit>) {
-                for (const tyir::TyStructInitField& field : node.fields)
+                bool reachable = true;
+                for (const tyir::TyStructInitField& field : node.fields) {
+                    if (!reachable)
+                        break;
                     availability =
                         tyir::availability_join(availability, availability_of_expr(field.value));
+                    reachable = field.value == nullptr || expr_can_fallthrough(*field.value);
+                }
             } else if constexpr (
                 std::is_same_v<Node, tyir::TyBorrow> || std::is_same_v<Node, tyir::TyUnary>) {
                 availability =
@@ -333,17 +338,26 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
             } else if constexpr (std::is_same_v<Node, tyir::TyBinary>) {
                 availability =
                     tyir::availability_join(availability, availability_of_expr(node.lhs));
-                availability =
-                    tyir::availability_join(availability, availability_of_expr(node.rhs));
+                if (node.lhs != nullptr && expr_can_fallthrough(*node.lhs))
+                    availability =
+                        tyir::availability_join(availability, availability_of_expr(node.rhs));
             } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
                 availability =
                     tyir::availability_join(availability, availability_of_expr(node.base));
             } else if constexpr (
                 std::is_same_v<Node, tyir::TyCall>
                 || std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
-                availability = tyir::availability_join(availability, expr.availability);
-                for (const tyir::TyExprPtr& arg : node.args)
+                bool reachable = true;
+                for (const tyir::TyExprPtr& arg : node.args) {
+                    if (arg == nullptr)
+                        continue;
+                    if (!reachable)
+                        break;
                     availability = tyir::availability_join(availability, availability_of_expr(arg));
+                    reachable = expr_can_fallthrough(*arg);
+                }
+                if (reachable)
+                    availability = tyir::availability_join(availability, expr.availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
                 availability =
                     tyir::availability_join(availability, runtime_block_availability(expr.span));

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -1851,7 +1851,8 @@ ConstraintEvalResult evaluate_constraint(
                 ConstraintEvalKind::Unsatisfied, "probed expression is not type-valid",
                 std::nullopt};
         }
-        if (has_runtime_barrier(*expr) && !expr_contains_local_ref(expr)) {
+        if (!std::holds_alternative<tyir::TyBlockPtr>(expr->node) && has_runtime_barrier(*expr)
+            && !expr_contains_local_ref(expr)) {
             return {
                 ConstraintEvalKind::Unsatisfied,
                 "probed expression uses runtime-only behavior",
@@ -2245,6 +2246,8 @@ ConstraintEvalResult evaluate_constraint(
                             stmt);
                         if (nested.kind != ConstraintEvalKind::Satisfied)
                             return nested;
+                        if (!stmt_can_fallthrough(stmt))
+                            return {ConstraintEvalKind::Satisfied, {}, std::nullopt};
                     }
                     if (node->tail.has_value())
                         return self(self, *node->tail);

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -3684,6 +3684,8 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
             }
 
             if constexpr (std::is_same_v<Node, tyir::TyCall>) {
+                if (!tyir::is_ct_available(expr))
+                    return expr;
                 std::vector<tyir::TyExprPtr> args;
                 args.reserve(node.args.size());
                 for (const tyir::TyExprPtr& arg : node.args) {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -265,6 +265,10 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 
 [[nodiscard]] static bool stmt_can_fallthrough(const tyir::TyStmt& stmt);
 
+[[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
+
+[[nodiscard]] static bool block_can_fallthrough(const tyir::TyBlock& block);
+
 [[nodiscard]] static tyir::Availability availability_of_expr(const tyir::TyExprPtr& expr) {
     return expr != nullptr ? expr->availability : tyir::availability_ct();
 }
@@ -364,17 +368,26 @@ static void recompute_expr_availability(tyir::TyExpr& expr) {
                 availability =
                     tyir::availability_join(availability, availability_of_block(node.body));
             } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
-                if (node.init.has_value())
+                bool reachable = true;
+                if (node.init.has_value() && reachable) {
                     availability = tyir::availability_join(
                         availability, availability_of_expr(node.init->init));
-                if (node.condition.has_value())
+                    reachable = expr_can_fallthrough(*node.init->init);
+                }
+                if (node.condition.has_value() && reachable) {
                     availability = tyir::availability_join(
                         availability, availability_of_expr(*node.condition));
-                if (node.step.has_value())
+                    reachable = expr_can_fallthrough(**node.condition);
+                }
+                const bool body_reachable = reachable;
+                if (body_reachable)
+                    availability =
+                        tyir::availability_join(availability, availability_of_block(node.body));
+                if (node.step.has_value() && body_reachable && node.body != nullptr
+                    && block_can_fallthrough(*node.body)) {
                     availability =
                         tyir::availability_join(availability, availability_of_expr(*node.step));
-                availability =
-                    tyir::availability_join(availability, availability_of_block(node.body));
+                }
             } else if constexpr (
                 std::is_same_v<Node, tyir::TyBreak> || std::is_same_v<Node, tyir::TyReturn>) {
                 if (node.value.has_value())
@@ -3229,8 +3242,6 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
     const tyir::TyExprPtr& expr, ConstEnv& env, const ProgramView& program,
     const GenericParamSet& generic_params);
 
-[[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr);
-
 [[nodiscard]] static bool stmt_can_fallthrough(const tyir::TyStmt& stmt) {
     return std::visit(
         [](const auto& node) {
@@ -3242,8 +3253,6 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
         },
         stmt);
 }
-
-[[nodiscard]] static bool block_can_fallthrough(const tyir::TyBlock& block);
 
 [[nodiscard]] static bool expr_can_fallthrough(const tyir::TyExpr& expr) {
     if (expr.ty.is_never())

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -367,7 +367,7 @@ fn main() {
     assert(main_fn != nullptr);
     assert(main_fn->body != nullptr);
     auto runtime_unit = make_ty_expr(
-        {}, TyLiteral{TyLiteral::Kind::Unit, kInvalidSymbol, false}, ty::unit(), false);
+        {}, TyLiteral{TyLiteral::Kind::Unit, kInvalidSymbol, false}, ty::unit(), availability_rt());
     assert(runtime_unit->ty == ty::unit());
     assert(runtime_unit->availability.kind == AvailabilityKind::Rt);
     main_fn->body->stmts.insert(
@@ -379,7 +379,7 @@ fn main() {
     const TyFnDecl& folded_main = find_fn(*folded, "main");
     const auto& runtime_stmt = std::get<TyExprStmt>(folded_main.body->stmts[0]);
     assert(runtime_stmt.expr->ty == ty::unit());
-    assert(!runtime_stmt.expr->ct_available);
+    assert(!is_ct_available(*runtime_stmt.expr));
     assert(runtime_stmt.expr->availability.kind == AvailabilityKind::Rt);
     assert(std::holds_alternative<TyLiteral>(runtime_stmt.expr->node));
 

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -339,6 +339,56 @@ fn main() {
     assert(folded_call.symbol.as_str() == std::string_view{"1"});
 }
 
+static void test_plain_type_runtime_availability_is_preserved() {
+    SymbolSession session;
+
+    const auto ast = cstc::parser::parse_source(R"(
+fn one() -> num { 1 }
+
+fn main() {
+    one();
+}
+)");
+    assert(ast.has_value());
+
+    auto tyir = cstc::tyir_builder::lower_program(*ast);
+    assert(tyir.has_value());
+
+    TyProgram program = *tyir;
+    TyFnDecl* main_fn = nullptr;
+    for (TyItem& item : program.items) {
+        if (auto* fn = std::get_if<TyFnDecl>(&item);
+            fn != nullptr && fn->name == Symbol::intern("main")) {
+            main_fn = fn;
+            break;
+        }
+    }
+
+    assert(main_fn != nullptr);
+    assert(main_fn->body != nullptr);
+    auto runtime_unit = make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Unit, kInvalidSymbol, false}, ty::unit(), false);
+    assert(runtime_unit->ty == ty::unit());
+    assert(runtime_unit->availability.kind == AvailabilityKind::Rt);
+    main_fn->body->stmts.insert(
+        main_fn->body->stmts.begin(), TyExprStmt{std::move(runtime_unit), {}});
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(folded.has_value());
+
+    const TyFnDecl& folded_main = find_fn(*folded, "main");
+    const auto& runtime_stmt = std::get<TyExprStmt>(folded_main.body->stmts[0]);
+    assert(runtime_stmt.expr->ty == ty::unit());
+    assert(!runtime_stmt.expr->ct_available);
+    assert(runtime_stmt.expr->availability.kind == AvailabilityKind::Rt);
+    assert(std::holds_alternative<TyLiteral>(runtime_stmt.expr->node));
+
+    const auto& folded_call_stmt = std::get<TyExprStmt>(folded_main.body->stmts[1]);
+    const TyLiteral& folded_call = require_literal(folded_call_stmt.expr);
+    assert(folded_call.kind == TyLiteral::Kind::Num);
+    assert(folded_call.symbol.as_str() == std::string_view{"1"});
+}
+
 static void test_short_circuit_boolean_ops_do_not_eval_dead_rhs() {
     SymbolSession session;
     const auto program = must_fold(R"(
@@ -2773,6 +2823,7 @@ int main() {
     test_runtime_block_preserves_runtime_call_boundary();
     test_runtime_block_with_null_body_is_preserved();
     test_runtime_block_stmt_with_null_body_still_falls_through();
+    test_plain_type_runtime_availability_is_preserved();
     test_short_circuit_boolean_ops_do_not_eval_dead_rhs();
     test_move_only_local_and_borrow_can_fold();
     test_move_only_return_materializes_owned_string();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -377,6 +377,8 @@ fn main() {
     assert(folded.has_value());
 
     const TyFnDecl& folded_main = find_fn(*folded, "main");
+    assert(folded_main.body != nullptr);
+    assert(folded_main.body->stmts.size() == 2);
     const auto& runtime_stmt = std::get<TyExprStmt>(folded_main.body->stmts[0]);
     assert(runtime_stmt.expr->ty == ty::unit());
     assert(!is_ct_available(*runtime_stmt.expr));

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -316,6 +316,48 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
     assert(call.args.front()->ty == ty::num());
 }
 
+static void test_rt_available_call_with_foldable_argument_remains_in_tyir() {
+    SymbolSession session;
+    const Symbol id_name = Symbol::intern("id");
+    const Symbol generic_name = Symbol::intern("T");
+    const Symbol value_name = Symbol::intern("value");
+
+    TyProgram program;
+    program.items.push_back(make_generic_identity_fn(id_name, generic_name, value_name));
+
+    TyBlock main_body;
+    main_body.ty = ty::num(true);
+    TyBinary add_arg{cstc::ast::BinaryOp::Add, make_num_expr("1"), make_num_expr("2")};
+    auto arg = make_ty_expr({}, add_arg, ty::num());
+    main_body.tail = make_ty_expr(
+        {}, TyCall{id_name, {ty::num()}, {std::move(arg)}}, ty::num(true),
+        runtime_result_call_availability());
+    program.items.push_back(
+        TyFnDecl{
+            .name = Symbol::intern("main"),
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(true),
+            .body = std::make_shared<TyBlock>(std::move(main_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+        });
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(folded.has_value());
+
+    const TyExprPtr& tail = require_tail(find_fn(*folded, "main"));
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    assert(tail->availability.evidence.has_value());
+    assert(tail->availability.evidence->reason == "runtime-result call");
+    const TyCall& call = require_call(tail);
+    assert(call.fn_name == id_name);
+    assert(call.args.size() == 1);
+    assert(std::holds_alternative<TyBinary>(call.args.front()->node));
+}
+
 static void test_null_evidence_rt_call_remains_in_tyir() {
     SymbolSession session;
     TyProgram program = must_lower_with_constraint_prelude(R"(
@@ -850,9 +892,8 @@ fn main() {
     assert(print_call.args.size() == 1);
     assert(std::holds_alternative<TyBorrow>(print_call.args[0]->node));
     const auto& borrow = std::get<TyBorrow>(print_call.args[0]->node);
-    const TyLiteral& borrow_literal = require_literal(borrow.rhs);
-    assert(borrow_literal.kind == TyLiteral::Kind::OwnedStr);
-    assert(borrow_literal.symbol.as_str() == std::string_view{"\"42\""});
+    assert(std::holds_alternative<LocalRef>(borrow.rhs->node));
+    assert(std::get<LocalRef>(borrow.rhs->node).name == Symbol::intern("rendered"));
 }
 
 static void test_borrow_preserves_folded_rhs_when_ref_cannot_materialize() {
@@ -876,9 +917,7 @@ fn main() {
     assert(std::holds_alternative<TyBorrow>(sink_call.args[0]->node));
 
     const auto& borrow = std::get<TyBorrow>(sink_call.args[0]->node);
-    const TyLiteral& literal = require_literal(borrow.rhs);
-    assert(literal.kind == TyLiteral::Kind::Num);
-    assert(literal.symbol.as_str() == std::string_view{"3"});
+    assert(std::holds_alternative<TyBinary>(borrow.rhs->node));
 }
 
 static void test_runtime_intrinsic_call_is_preserved() {
@@ -3263,6 +3302,7 @@ int main() {
     test_runtime_call_remains_in_tyir();
     test_plain_call_with_runtime_argument_remains_in_tyir();
     test_runtime_result_call_with_ct_argument_remains_in_tyir();
+    test_rt_available_call_with_foldable_argument_remains_in_tyir();
     test_null_evidence_rt_call_remains_in_tyir();
     test_runtime_block_folds_pure_inner_expression();
     test_runtime_block_preserves_runtime_call_boundary();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -1007,6 +1007,31 @@ fn main() {
     assert(folded_assert.kind == TyLiteral::Kind::Unit);
 }
 
+static void test_decl_probe_ignores_dead_stmt_after_nonfallthrough_call() {
+    SymbolSession session;
+    const auto program = must_fold_with_constraint_prelude(R"(
+fn stop(flag: bool) -> ! {
+    loop { if flag { } }
+}
+
+fn main() -> num {
+    decl({ stop(true); runtime { 2 }; });
+    0
+}
+)");
+
+    const TyFnDecl& main_fn = find_fn(program, "main");
+    assert(main_fn.body != nullptr);
+    assert(!main_fn.body->stmts.empty());
+    const auto& probe_stmt = std::get<TyExprStmt>(main_fn.body->stmts[0]);
+    const EnumVariantRef& result = require_constraint_variant(probe_stmt.expr);
+    assert(result.variant_name == Symbol::intern("Valid"));
+
+    const TyLiteral& literal = require_literal(require_tail(main_fn));
+    assert(literal.kind == TyLiteral::Kind::Num);
+    assert(literal.symbol.as_str() == std::string_view{"0"});
+}
+
 static void test_dead_tail_after_break_is_not_folded() {
     SymbolSession session;
     const auto program = must_fold(R"(
@@ -3211,6 +3236,7 @@ int main() {
     test_dead_for_still_folds_reachable_init();
     test_dead_stmt_after_return_is_not_folded();
     test_decl_probe_does_not_stop_reachable_stmt_folding();
+    test_decl_probe_ignores_dead_stmt_after_nonfallthrough_call();
     test_dead_tail_after_break_is_not_folded();
     test_dead_tail_after_continue_is_not_folded();
     test_reached_assertion_failure_reports_error();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -497,6 +497,34 @@ fn main() -> num {
     assert(is_ct_available(*main_fn.body));
 }
 
+static void test_folded_operands_recompute_availability_with_reachability() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+runtime fn source(left: num, right: num) -> num {
+    right
+}
+
+struct Pair { left: num, right: num }
+
+fn call_case() -> num {
+    source((return 1), runtime { 2 })
+}
+
+fn binary_case() -> num {
+    (return 1) + runtime { 2 }
+}
+
+fn struct_case() -> num {
+    Pair { left: return 1, right: runtime { 2 } };
+    0
+}
+)");
+
+    assert(is_ct_available(*find_fn(program, "call_case").body));
+    assert(is_ct_available(*find_fn(program, "binary_case").body));
+    assert(is_ct_available(*find_fn(program, "struct_case").body));
+}
+
 static void test_decl_generic_ct_block_argument_rechecks_availability_after_substitution() {
     SymbolSession session;
     const auto error = must_fail_to_fold_with_constraint_prelude(R"(
@@ -3038,6 +3066,7 @@ int main() {
     test_plain_type_runtime_availability_is_preserved();
     test_folded_if_recomputes_availability_after_erasing_runtime_branch();
     test_folded_for_recomputes_availability_with_reachability();
+    test_folded_operands_recompute_availability_with_reachability();
     test_decl_generic_ct_block_argument_rechecks_availability_after_substitution();
     test_short_circuit_boolean_ops_do_not_eval_dead_rhs();
     test_move_only_local_and_borrow_can_fold();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -286,7 +286,7 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
     TyBlock main_body;
     main_body.ty = ty::num(true);
     main_body.tail = make_ty_expr(
-        {}, TyCall{id_name, {ty::num(true)}, {make_num_expr("1")}}, ty::num(true),
+        {}, TyCall{id_name, {ty::num()}, {make_num_expr("1")}}, ty::num(true),
         runtime_result_call_availability());
     program.items.push_back(
         TyFnDecl{

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -288,6 +288,9 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
 
     const TyExprPtr& tail = require_tail(find_fn(*folded, "main"));
     assert(tail->ty == ty::num(true));
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    assert(tail->availability.evidence.has_value());
+    assert(tail->availability.evidence->reason == "runtime-result call");
     const TyCall& call = require_call(tail);
     assert(call.fn_name == Symbol::intern("id"));
     assert(call.generic_args.size() == 1);

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -134,6 +134,12 @@ static const TyExprPtr& require_tail(const TyFnDecl& fn) {
     return *fn.body->tail;
 }
 
+static TyExprPtr& require_tail(TyFnDecl& fn) {
+    assert(fn.body != nullptr);
+    assert(fn.body->tail.has_value());
+    return *fn.body->tail;
+}
+
 static const TyLiteral& require_literal(const TyExprPtr& expr) {
     assert(std::holds_alternative<TyLiteral>(expr->node));
     return std::get<TyLiteral>(expr->node);
@@ -370,7 +376,7 @@ fn main() -> runtime num {
 }
 )");
 
-    TyExprPtr& tail = *find_fn(program, "main").body->tail;
+    TyExprPtr& tail = require_tail(find_fn(program, "main"));
     set_availability(*tail, availability_rt());
     assert(tail->availability.kind == AvailabilityKind::Rt);
     assert(!tail->availability.evidence.has_value());
@@ -1687,7 +1693,7 @@ fn probe() -> Constraint {
 }
 )");
 
-    TyExprPtr& tail = *find_fn(program, "probe").body->tail;
+    TyExprPtr& tail = require_tail(find_fn(program, "probe"));
     TyDeclProbe& probe = std::get<TyDeclProbe>(tail->node);
     assert(probe.expr.has_value());
     set_availability(**probe.expr, availability_rt());

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -141,6 +141,39 @@ static const EnumVariantRef& require_constraint_variant(const TyExprPtr& expr) {
     return std::get<EnumVariantRef>(expr->node);
 }
 
+static Ty generic_copy_ty(Symbol generic_name) {
+    return ty::named(generic_name, generic_name, ValueSemantics::Copy);
+}
+
+static Availability runtime_result_call_availability() {
+    return availability_rt(TyRuntimeEvidence{{}, "runtime-result call"});
+}
+
+static TyExprPtr make_num_expr(std::string_view value) {
+    return make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Num, Symbol::intern(value), false}, ty::num());
+}
+
+static TyFnDecl make_generic_identity_fn(Symbol fn_name, Symbol generic_name, Symbol value_name) {
+    const Ty generic_ty = generic_copy_ty(generic_name);
+
+    TyBlock body;
+    body.ty = generic_ty;
+    body.tail = make_ty_expr({}, LocalRef{value_name}, generic_ty);
+
+    return TyFnDecl{
+        .name = fn_name,
+        .generic_params = {{generic_name, {}}},
+        .params = {TyParam{value_name, generic_ty, {}, ParamRequirement::RuntimeAllowed}},
+        .return_ty = generic_ty,
+        .body = std::make_shared<TyBlock>(std::move(body)),
+        .span = {},
+        .is_runtime = false,
+        .where_clause = {},
+        .lowered_where_clause = {},
+    };
+}
+
 struct DeclProbeRecheckCase {
     const char* folded_source;
     TyLiteral::Kind literal_kind;
@@ -221,6 +254,45 @@ fn main() -> runtime num {
     assert(call.fn_name == Symbol::intern("inc"));
     assert(call.args.size() == 1);
     assert(call.args[0]->ty == ty::num(true));
+}
+
+static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
+    SymbolSession session;
+    const Symbol id_name = Symbol::intern("id");
+    const Symbol generic_name = Symbol::intern("T");
+    const Symbol value_name = Symbol::intern("value");
+
+    TyProgram program;
+    program.items.push_back(make_generic_identity_fn(id_name, generic_name, value_name));
+
+    TyBlock main_body;
+    main_body.ty = ty::num(true);
+    main_body.tail = make_ty_expr(
+        {}, TyCall{id_name, {ty::num(true)}, {make_num_expr("1")}}, ty::num(true),
+        runtime_result_call_availability());
+    program.items.push_back(
+        TyFnDecl{
+            .name = Symbol::intern("main"),
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(true),
+            .body = std::make_shared<TyBlock>(std::move(main_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+        });
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(folded.has_value());
+
+    const TyExprPtr& tail = require_tail(find_fn(*folded, "main"));
+    assert(tail->ty == ty::num(true));
+    const TyCall& call = require_call(tail);
+    assert(call.fn_name == Symbol::intern("id"));
+    assert(call.generic_args.size() == 1);
+    assert(call.args.size() == 1);
+    assert(call.args.front()->ty == ty::num());
 }
 
 static void test_runtime_block_folds_pure_inner_expression() {
@@ -2691,6 +2763,85 @@ fn main() -> num {
     assert(error.message.find("function 'id'") != std::string::npos);
 }
 
+static void test_decl_generic_runtime_result_call_fails_after_substitution() {
+    SymbolSession session;
+    const Symbol constraint_name = Symbol::intern("Constraint");
+    const Symbol constraint_fn = Symbol::intern("constraint");
+    const Symbol id_name = Symbol::intern("id");
+    const Symbol wrapper_name = Symbol::intern("wrapper");
+    const Symbol generic_name = Symbol::intern("T");
+    const Symbol value_name = Symbol::intern("value");
+    const Ty generic_ty = generic_copy_ty(generic_name);
+    const Ty constraint_ty = ty::named(constraint_name, constraint_name, ValueSemantics::Copy);
+
+    TyProgram program;
+    TyEnumDecl constraint_enum;
+    constraint_enum.name = constraint_name;
+    constraint_enum.lang_name = Symbol::intern("cstc_constraint");
+    constraint_enum.variants.push_back(TyEnumVariant{Symbol::intern("Valid"), std::nullopt, {}});
+    constraint_enum.variants.push_back(TyEnumVariant{Symbol::intern("Invalid"), std::nullopt, {}});
+    program.items.push_back(std::move(constraint_enum));
+    program.items.push_back(
+        TyExternFnDecl{
+            .abi = Symbol::intern("lang"),
+            .name = constraint_fn,
+            .link_name = kInvalidSymbol,
+            .params = {TyParam{
+                Symbol::intern("value"), ty::bool_(), {}, ParamRequirement::RuntimeAllowed}},
+            .return_ty = constraint_ty,
+            .span = {},
+            .is_runtime = false,
+        });
+    program.items.push_back(make_generic_identity_fn(id_name, generic_name, value_name));
+
+    auto make_inner_call = [&]() {
+        return make_ty_expr(
+            {}, TyCall{id_name, {generic_ty}, {make_num_expr("0")}}, generic_ty,
+            runtime_result_call_availability());
+    };
+    auto equality = make_ty_expr(
+        {}, TyBinary{cstc::ast::BinaryOp::Eq, make_inner_call(), make_inner_call()}, ty::bool_());
+    auto constraint_expr =
+        make_ty_expr({}, TyCall{constraint_fn, {}, {std::move(equality)}}, constraint_ty);
+
+    TyBlock wrapper_body;
+    wrapper_body.ty = ty::num();
+    wrapper_body.tail = make_num_expr("1");
+    program.items.push_back(
+        TyFnDecl{
+            .name = wrapper_name,
+            .generic_params = {{generic_name, {}}},
+            .params = {},
+            .return_ty = ty::num(),
+            .body = std::make_shared<TyBlock>(std::move(wrapper_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {TyGenericConstraint{constraint_expr, {}}},
+        });
+
+    TyBlock main_body;
+    main_body.ty = ty::num();
+    main_body.tail = make_ty_expr({}, TyCall{wrapper_name, {ty::num(true)}, {}}, ty::num());
+    program.items.push_back(
+        TyFnDecl{
+            .name = Symbol::intern("main"),
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(),
+            .body = std::make_shared<TyBlock>(std::move(main_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+        });
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(!folded.has_value());
+    assert(folded.error().message.find("runtime-only behavior") != std::string::npos);
+    assert(folded.error().message.find("function 'wrapper'") != std::string::npos);
+}
+
 static void test_generic_where_runtime_loop_reports_runtime_only() {
     SymbolSession session;
     const auto error = must_fail_to_lower_with_constraint_prelude(R"(
@@ -2862,6 +3013,7 @@ int main() {
     test_const_function_call_folds_to_literal();
     test_runtime_call_remains_in_tyir();
     test_plain_call_with_runtime_argument_remains_in_tyir();
+    test_runtime_result_call_with_ct_argument_remains_in_tyir();
     test_runtime_block_folds_pure_inner_expression();
     test_runtime_block_preserves_runtime_call_boundary();
     test_runtime_block_with_null_body_is_preserved();
@@ -2958,6 +3110,7 @@ int main() {
     test_explicit_constraint_invalid_reports_constraint_failure();
     test_generic_where_parameter_references_are_rejected_while_lowering();
     test_generic_where_runtime_call_reports_runtime_only();
+    test_decl_generic_runtime_result_call_fails_after_substitution();
     test_generic_where_runtime_loop_reports_runtime_only();
     test_generic_where_runtime_while_reports_runtime_only();
     test_unused_generic_where_is_deferred_until_instantiation();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -102,6 +102,19 @@ static const TyFnDecl& find_fn(const TyProgram& program, std::string_view name) 
     std::abort();
 }
 
+static TyFnDecl& find_fn(TyProgram& program, std::string_view name) {
+    const Symbol fn_name = Symbol::intern(name);
+    for (TyItem& item : program.items) {
+        if (auto* fn = std::get_if<TyFnDecl>(&item)) {
+            if (fn->name == fn_name)
+                return *fn;
+        }
+    }
+
+    assert(false && "function not found");
+    std::abort();
+}
+
 static const TyStructDecl& find_struct(const TyProgram& program, std::string_view name) {
     const Symbol struct_name = Symbol::intern(name);
     for (const TyItem& item : program.items) {
@@ -296,6 +309,33 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
     assert(call.generic_args.size() == 1);
     assert(call.args.size() == 1);
     assert(call.args.front()->ty == ty::num());
+}
+
+static void test_null_evidence_rt_call_remains_in_tyir() {
+    SymbolSession session;
+    TyProgram program = must_lower_with_constraint_prelude(R"(
+fn one() -> num {
+    1
+}
+
+fn main() -> runtime num {
+    one()
+}
+)");
+
+    TyExprPtr& tail = *find_fn(program, "main").body->tail;
+    set_availability(*tail, availability_rt());
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    assert(!tail->availability.evidence.has_value());
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(folded.has_value());
+
+    const TyExprPtr& folded_tail = require_tail(find_fn(*folded, "main"));
+    assert(folded_tail->availability.kind == AvailabilityKind::Rt);
+    assert(!folded_tail->availability.evidence.has_value());
+    const TyCall& call = require_call(folded_tail);
+    assert(call.fn_name == Symbol::intern("one"));
 }
 
 static void test_runtime_block_folds_pure_inner_expression() {
@@ -1465,6 +1505,29 @@ fn probe() -> Constraint {
 
     assert(
         require_constraint_variant(require_tail(find_fn(program, "probe"))).variant_name
+        == Symbol::intern("Invalid"));
+}
+
+static void test_decl_null_evidence_rt_probe_folds_to_constraint_invalid() {
+    SymbolSession session;
+    TyProgram program = must_lower_with_constraint_prelude(R"(
+fn probe() -> Constraint {
+    decl(1)
+}
+)");
+
+    TyExprPtr& tail = *find_fn(program, "probe").body->tail;
+    TyDeclProbe& probe = std::get<TyDeclProbe>(tail->node);
+    assert(probe.expr.has_value());
+    set_availability(**probe.expr, availability_rt());
+    assert((*probe.expr)->availability.kind == AvailabilityKind::Rt);
+    assert(!(*probe.expr)->availability.evidence.has_value());
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(folded.has_value());
+
+    assert(
+        require_constraint_variant(require_tail(find_fn(*folded, "probe"))).variant_name
         == Symbol::intern("Invalid"));
 }
 
@@ -3068,6 +3131,7 @@ int main() {
     test_runtime_call_remains_in_tyir();
     test_plain_call_with_runtime_argument_remains_in_tyir();
     test_runtime_result_call_with_ct_argument_remains_in_tyir();
+    test_null_evidence_rt_call_remains_in_tyir();
     test_runtime_block_folds_pure_inner_expression();
     test_runtime_block_preserves_runtime_call_boundary();
     test_runtime_block_with_null_body_is_preserved();
@@ -3120,6 +3184,7 @@ int main() {
     test_decl_valid_probe_folds_to_constraint_valid();
     test_decl_invalid_probe_folds_to_constraint_invalid();
     test_decl_runtime_probe_folds_to_constraint_invalid();
+    test_decl_null_evidence_rt_probe_folds_to_constraint_invalid();
     test_decl_where_clause_accepts_parameter_references();
     test_decl_probe_defers_nested_function_constraint_failures();
     test_decl_probe_defers_nested_struct_constraint_failures();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -368,7 +368,7 @@ fn main() {
     assert(main_fn->body != nullptr);
     auto runtime_unit = make_ty_expr(
         {}, TyLiteral{TyLiteral::Kind::Unit, kInvalidSymbol, false}, ty::unit(), availability_rt());
-    assert(runtime_unit->ty == ty::unit());
+    assert(runtime_unit->ty == ty::unit(true));
     assert(runtime_unit->availability.kind == AvailabilityKind::Rt);
     main_fn->body->stmts.insert(
         main_fn->body->stmts.begin(), TyExprStmt{std::move(runtime_unit), {}});
@@ -380,7 +380,7 @@ fn main() {
     assert(folded_main.body != nullptr);
     assert(folded_main.body->stmts.size() == 2);
     const auto& runtime_stmt = std::get<TyExprStmt>(folded_main.body->stmts[0]);
-    assert(runtime_stmt.expr->ty == ty::unit());
+    assert(runtime_stmt.expr->ty == ty::unit(true));
     assert(!is_ct_available(*runtime_stmt.expr));
     assert(runtime_stmt.expr->availability.kind == AvailabilityKind::Rt);
     assert(std::holds_alternative<TyLiteral>(runtime_stmt.expr->node));

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -572,6 +572,31 @@ fn main() -> num {
     assert(is_ct_available(*main_fn.body));
 }
 
+static void test_control_children_recompute_availability_with_reachability() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+fn if_case() -> num {
+    if (return 1) { runtime { 2 } } else { runtime { 3 } }
+}
+
+fn while_case() -> num {
+    while (return 1) { runtime { 2 }; }
+    0
+}
+)");
+
+    const TyFnDecl& if_case = find_fn(program, "if_case");
+    assert(is_ct_available(*require_tail(if_case)));
+    assert(is_ct_available(*if_case.body));
+
+    const TyFnDecl& while_case = find_fn(program, "while_case");
+    assert(while_case.body != nullptr);
+    assert(!while_case.body->stmts.empty());
+    const auto& while_stmt = std::get<TyExprStmt>(while_case.body->stmts[0]);
+    assert(is_ct_available(*while_stmt.expr));
+    assert(is_ct_available(*while_case.body));
+}
+
 static void test_folded_operands_recompute_availability_with_reachability() {
     SymbolSession session;
     const auto program = must_fold(R"(
@@ -3166,6 +3191,7 @@ int main() {
     test_plain_type_runtime_availability_is_preserved();
     test_folded_if_recomputes_availability_after_erasing_runtime_branch();
     test_folded_for_recomputes_availability_with_reachability();
+    test_control_children_recompute_availability_with_reachability();
     test_folded_operands_recompute_availability_with_reachability();
     test_decl_generic_ct_block_argument_rechecks_availability_after_substitution();
     test_short_circuit_boolean_ops_do_not_eval_dead_rhs();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -1584,6 +1584,36 @@ fn probe() -> Constraint {
         == Symbol::intern("Invalid"));
 }
 
+static void test_decl_runtime_block_with_local_ref_folds_to_constraint_invalid() {
+    SymbolSession session;
+    const auto program = must_fold_with_constraint_prelude(R"(
+fn probe(value: num) -> Constraint {
+    decl(runtime { value })
+}
+)");
+
+    assert(
+        require_constraint_variant(require_tail(find_fn(program, "probe"))).variant_name
+        == Symbol::intern("Invalid"));
+}
+
+static void test_decl_runtime_field_access_with_local_ref_folds_to_constraint_invalid() {
+    SymbolSession session;
+    const auto program = must_fold_with_constraint_prelude(R"(
+struct Box {
+    value: runtime num
+}
+
+fn probe(box: Box) -> Constraint {
+    decl(box.value)
+}
+)");
+
+    assert(
+        require_constraint_variant(require_tail(find_fn(program, "probe"))).variant_name
+        == Symbol::intern("Invalid"));
+}
+
 static void test_decl_null_evidence_rt_probe_folds_to_constraint_invalid() {
     SymbolSession session;
     TyProgram program = must_lower_with_constraint_prelude(R"(
@@ -3263,6 +3293,8 @@ int main() {
     test_decl_valid_probe_folds_to_constraint_valid();
     test_decl_invalid_probe_folds_to_constraint_invalid();
     test_decl_runtime_probe_folds_to_constraint_invalid();
+    test_decl_runtime_block_with_local_ref_folds_to_constraint_invalid();
+    test_decl_runtime_field_access_with_local_ref_folds_to_constraint_invalid();
     test_decl_null_evidence_rt_probe_folds_to_constraint_invalid();
     test_decl_where_clause_accepts_parameter_references();
     test_decl_probe_defers_nested_function_constraint_failures();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -389,6 +389,47 @@ fn main() {
     assert(folded_call.symbol.as_str() == std::string_view{"1"});
 }
 
+static void test_folded_if_recomputes_availability_after_erasing_runtime_branch() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+fn choose(value: num) -> num {
+    if true { 1 } else { value }
+}
+)");
+
+    const TyFnDecl& choose = find_fn(program, "choose");
+    const TyExprPtr& tail = require_tail(choose);
+    const TyLiteral& literal = require_literal(tail);
+    assert(literal.kind == TyLiteral::Kind::Num);
+    assert(literal.symbol.as_str() == std::string_view{"1"});
+    assert(is_ct_available(*tail));
+    assert(is_ct_available(*choose.body));
+}
+
+static void test_decl_generic_ct_block_argument_rechecks_availability_after_substitution() {
+    SymbolSession session;
+    const auto error = must_fail_to_fold_with_constraint_prelude(R"(
+fn reserve(value: const num) -> num {
+    value
+}
+
+fn probe<T>() -> Constraint {
+    decl(reserve({ let value: T = 0; value }))
+}
+
+fn wrapper<T>() -> num where probe::<T>() {
+    1
+}
+
+fn main() -> num {
+    wrapper::<runtime num>()
+}
+)");
+
+    assert(error.message.find("generic constraint failed") != std::string::npos);
+    assert(error.message.find("function 'wrapper'") != std::string::npos);
+}
+
 static void test_short_circuit_boolean_ops_do_not_eval_dead_rhs() {
     SymbolSession session;
     const auto program = must_fold(R"(
@@ -2824,6 +2865,8 @@ int main() {
     test_runtime_block_with_null_body_is_preserved();
     test_runtime_block_stmt_with_null_body_still_falls_through();
     test_plain_type_runtime_availability_is_preserved();
+    test_folded_if_recomputes_availability_after_erasing_runtime_branch();
+    test_decl_generic_ct_block_argument_rechecks_availability_after_substitution();
     test_short_circuit_boolean_ops_do_not_eval_dead_rhs();
     test_move_only_local_and_borrow_can_fold();
     test_move_only_return_materializes_owned_string();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -1614,6 +1614,32 @@ fn probe(box: Box) -> Constraint {
         == Symbol::intern("Invalid"));
 }
 
+static void test_decl_let_initializer_with_runtime_value_stays_invalid() {
+    SymbolSession session;
+    const auto program = must_fold_with_constraint_prelude(R"(
+fn probe(value: runtime num) -> Constraint {
+    decl({ let x: num = value; x })
+}
+)");
+
+    assert(
+        require_constraint_variant(require_tail(find_fn(program, "probe"))).variant_name
+        == Symbol::intern("Invalid"));
+}
+
+static void test_decl_for_initializer_with_runtime_value_stays_invalid() {
+    SymbolSession session;
+    const auto program = must_fold_with_constraint_prelude(R"(
+fn probe(value: runtime num) -> Constraint {
+    decl({ for (let i: num = value; false; 0) { }; 0 })
+}
+)");
+
+    assert(
+        require_constraint_variant(require_tail(find_fn(program, "probe"))).variant_name
+        == Symbol::intern("Invalid"));
+}
+
 static void test_decl_null_evidence_rt_probe_folds_to_constraint_invalid() {
     SymbolSession session;
     TyProgram program = must_lower_with_constraint_prelude(R"(
@@ -3295,6 +3321,8 @@ int main() {
     test_decl_runtime_probe_folds_to_constraint_invalid();
     test_decl_runtime_block_with_local_ref_folds_to_constraint_invalid();
     test_decl_runtime_field_access_with_local_ref_folds_to_constraint_invalid();
+    test_decl_let_initializer_with_runtime_value_stays_invalid();
+    test_decl_for_initializer_with_runtime_value_stays_invalid();
     test_decl_null_evidence_rt_probe_folds_to_constraint_invalid();
     test_decl_where_clause_accepts_parameter_references();
     test_decl_probe_defers_nested_function_constraint_failures();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -309,7 +309,13 @@ fn main() -> runtime num {
     const TyExprPtr& tail = require_tail(find_fn(program, "main"));
     const auto& runtime_block = std::get<TyRuntimeBlock>(tail->node);
     assert(tail->ty == ty::num(true));
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    assert(tail->availability.evidence.has_value());
+    assert(tail->availability.evidence->reason == "runtime block");
+    assert(!is_ct_available(*tail));
+    assert(is_ct_available(*runtime_block.body));
     assert(runtime_block.body->tail.has_value());
+    assert(is_ct_available(*runtime_block.body->tail));
     const TyLiteral& literal = require_literal(*runtime_block.body->tail);
     assert(literal.kind == TyLiteral::Kind::Num);
     assert(literal.symbol.as_str() == std::string_view{"3"});

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -480,6 +480,23 @@ fn choose(value: num) -> num {
     assert(is_ct_available(*choose.body));
 }
 
+static void test_folded_for_recomputes_availability_with_reachability() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+fn main() -> num {
+    for (return 1; runtime { true }; runtime { 2 }) { runtime { 3 }; };
+    0
+}
+)");
+
+    const TyFnDecl& main_fn = find_fn(program, "main");
+    assert(main_fn.body != nullptr);
+    assert(!main_fn.body->stmts.empty());
+    const auto& for_stmt = std::get<TyExprStmt>(main_fn.body->stmts[0]);
+    assert(is_ct_available(*for_stmt.expr));
+    assert(is_ct_available(*main_fn.body));
+}
+
 static void test_decl_generic_ct_block_argument_rechecks_availability_after_substitution() {
     SymbolSession session;
     const auto error = must_fail_to_fold_with_constraint_prelude(R"(
@@ -3020,6 +3037,7 @@ int main() {
     test_runtime_block_stmt_with_null_body_still_falls_through();
     test_plain_type_runtime_availability_is_preserved();
     test_folded_if_recomputes_availability_after_erasing_runtime_branch();
+    test_folded_for_recomputes_availability_with_reachability();
     test_decl_generic_ct_block_argument_rechecks_availability_after_substitution();
     test_short_circuit_boolean_ops_do_not_eval_dead_rhs();
     test_move_only_local_and_borrow_can_fold();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -149,6 +149,11 @@ static const TyStructInit& require_struct_init(const TyExprPtr& expr) {
     return std::get<TyStructInit>(expr->node);
 }
 
+static const TyFieldAccess& require_field_access(const TyExprPtr& expr) {
+    assert(std::holds_alternative<TyFieldAccess>(expr->node));
+    return std::get<TyFieldAccess>(expr->node);
+}
+
 static const EnumVariantRef& require_constraint_variant(const TyExprPtr& expr) {
     assert(std::holds_alternative<EnumVariantRef>(expr->node));
     return std::get<EnumVariantRef>(expr->node);
@@ -379,6 +384,27 @@ fn main() -> runtime num {
     assert(std::holds_alternative<TyCall>(binary.lhs->node));
     const TyLiteral& literal = require_literal(binary.rhs);
     assert(literal.symbol.as_str() == std::string_view{"1"});
+}
+
+static void test_runtime_field_decl_preserves_runtime_boundary() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+struct Box {
+    value: runtime num
+}
+
+fn main() -> runtime num {
+    let box: Box = Box { value: 1 };
+    box.value
+}
+)");
+
+    const TyExprPtr& tail = require_tail(find_fn(program, "main"));
+    assert(tail->ty == ty::num(true));
+    assert(tail->availability.kind == AvailabilityKind::Rt);
+    const TyFieldAccess& access = require_field_access(tail);
+    assert(access.field == Symbol::intern("value"));
+    assert(is_ct_available(access.base));
 }
 
 static void test_runtime_block_with_null_body_is_preserved() {
@@ -3134,6 +3160,7 @@ int main() {
     test_null_evidence_rt_call_remains_in_tyir();
     test_runtime_block_folds_pure_inner_expression();
     test_runtime_block_preserves_runtime_call_boundary();
+    test_runtime_field_decl_preserves_runtime_boundary();
     test_runtime_block_with_null_body_is_preserved();
     test_runtime_block_stmt_with_null_body_still_falls_through();
     test_plain_type_runtime_availability_is_preserved();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -2830,7 +2830,7 @@ static void test_decl_generic_runtime_result_call_fails_after_substitution() {
         TyExternFnDecl{
             .abi = Symbol::intern("lang"),
             .name = constraint_fn,
-            .link_name = kInvalidSymbol,
+            .link_name = Symbol::intern("cstc_std_constraint"),
             .params = {TyParam{
                 Symbol::intern("value"), ty::bool_(), {}, ParamRequirement::RuntimeAllowed}},
             .return_ty = constraint_ty,

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -425,6 +425,12 @@ is runtime dependence introduced inside the body itself. An explicit plain retur
 annotation rejects such hidden runtime work; use `runtime fn`, `-> runtime T`, or
 an explicit runtime boundary when the runtime behavior is intentional.
 
+Inside a declaration body, an ordinary plain parameter keeps its plain type shape
+but carries symbolic runtime-allowed dependence. This lets the helper body type as
+plain for the all-static instantiation while still preventing that parameter from
+satisfying a `!runtime`/`const` requirement unless the requirement is explicit on
+the parameter or local being forwarded.
+
 ## 7. Valid Syntax Examples
 
 ```text

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -53,7 +53,7 @@ compatibility:
 - call arguments are matched by their non-`runtime` structure
 - passing `runtime T` to a plain parameter `T` is allowed for calls only
 - the resulting `TyCall` / `TyDeferredGenericCall` type is lifted to
-  `runtime U` when the callee or any argument is runtime-qualified
+  `runtime U` when the callee or any argument is runtime-available
 - this does not introduce a general `runtime T -> T` conversion for lets,
   returns, or other non-call sites
 
@@ -71,6 +71,13 @@ expression. If a function has an explicit plain result contract, that evidence
 must be reflected by `runtime fn` or a runtime-qualified return type; ordinary
 parameter dependence is still accepted because call-site lifting accounts for the
 actual arguments.
+
+Plain runtime-allowed parameters are represented inside a declaration body as
+compile-time-shaped values with symbolic parameter dependence. They do not make
+the body runtime-qualified by themselves, but they also cannot satisfy a
+CT-required position such as a `!runtime` parameter or `const` local annotation.
+At a call site, the argument availability instantiates that symbolic dependence
+and lifts the call result when an allowed argument is runtime-dependent.
 
 ## Generics and constraints
 

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -175,7 +175,7 @@ fn distance(p: Point, q: Point) -> num {
 
 Expression and block lines include `[availability: const]` or
 `[availability: runtime]` in the default inspector output. The compact example
-focuses on tree shape and type annotations.
+below omits availability annotations to focus on tree shape and type annotations.
 
 ```
 TyProgram

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -57,13 +57,16 @@ compatibility:
 - this does not introduce a general `runtime T -> T` conversion for lets,
   returns, or other non-call sites
 
-TyIR keeps the tag on `Ty` itself. Surface sugar such as `runtime fn` is
-normalized during lowering into a runtime-tagged return type, and TyIR also
-preserves the original declaration-level runtime marker on function items for
-later passes such as const-eval.
+TyIR stores expression and block availability in a canonical `Availability`
+summary. `AvailabilityKind::Ct` means the value is available to compile-time
+evaluation. `AvailabilityKind::Rt` means it depends on a runtime-qualified source,
+a runtime-result declaration, a runtime block, or a whole-term runtime
+contribution. Runtime-qualified display and lowering behavior are projections of
+that summary, while `Ty::is_runtime`, `ct_available`, and `runtime_evidence`
+remain as migration shims.
 
-TyIR also records body-internal runtime evidence separately from ordinary
-parameter availability. This evidence is joined across reachable lowered
+TyIR also records body-internal runtime evidence in `Availability::evidence` when
+a concrete origin exists. This evidence is joined across reachable lowered
 statements, control-flow headers, branch bodies, loop bodies, and the tail
 expression. If a function has an explicit plain result contract, that evidence
 must be reflected by `runtime fn` or a runtime-qualified return type; ordinary
@@ -97,8 +100,8 @@ backend must be concrete and all constraints must already have passed.
 
 ## Expression nodes
 
-Every expression in TyIR carries a resolved `Ty`.  The concrete expression
-variants are:
+Every expression in TyIR carries a resolved `Ty` and a canonical `Availability`.
+The concrete expression variants are:
 
 ```
 TyLiteral        — num/str/bool/()/Unit literal
@@ -130,11 +133,10 @@ A `TyBlock` has type:
 - The tail expression's type when a tail is present.
 - `Unit` when there is no tail expression.
 
-Its `ct_available` flag is whole-term: it joins reachable statement
-contributions and the tail expression rather than considering only the yielded
-value. `runtime_evidence` stores the first reachable body-internal runtime
-contributor so diagnostics can point at the non-tail statement or control-flow
-component that tainted the block.
+Its `availability` is whole-term: it joins reachable statement contributions and
+the tail expression rather than considering only the yielded value. The legacy
+`ct_available` and `runtime_evidence` fields mirror this summary so older passes
+can migrate incrementally.
 
 ## Runtime block type rules
 

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -62,8 +62,7 @@ summary. `AvailabilityKind::Ct` means the value is available to compile-time
 evaluation. `AvailabilityKind::Rt` means it depends on a runtime-qualified source,
 a runtime-result declaration, a runtime block, or a whole-term runtime
 contribution. Runtime-qualified display and lowering behavior are projections of
-that summary, while `Ty::is_runtime`, `ct_available`, and `runtime_evidence`
-remain as migration shims.
+that summary.
 
 TyIR also records body-internal runtime evidence in `Availability::evidence` when
 a concrete origin exists. This evidence is joined across reachable lowered
@@ -134,9 +133,7 @@ A `TyBlock` has type:
 - `Unit` when there is no tail expression.
 
 Its `availability` is whole-term: it joins reachable statement contributions and
-the tail expression rather than considering only the yielded value. The legacy
-`ct_available` and `runtime_evidence` fields mirror this summary so older passes
-can migrate incrementally.
+the tail expression rather than considering only the yielded value.
 
 ## Runtime block type rules
 
@@ -176,9 +173,9 @@ fn distance(p: Point, q: Point) -> num {
 }
 ```
 
-Expression and block lines include `[availability: CT]` or `[availability: RT]` in
-the default inspector output. The compact example focuses on tree shape and type
-annotations.
+Expression and block lines include `[availability: const]` or
+`[availability: runtime]` in the default inspector output. The compact example
+focuses on tree shape and type annotations.
 
 ```
 TyProgram

--- a/docs/language/tyir.md
+++ b/docs/language/tyir.md
@@ -176,6 +176,10 @@ fn distance(p: Point, q: Point) -> num {
 }
 ```
 
+Expression and block lines include `[availability: CT]` or `[availability: RT]` in
+the default inspector output. The compact example focuses on tree shape and type
+annotations.
+
 ```
 TyProgram
   TyStructDecl Point

--- a/test/availability_evidence/diagnostics/plain_call_forwarded_runtime_param_demotion.patterns
+++ b/test/availability_evidence/diagnostics/plain_call_forwarded_runtime_param_demotion.patterns
@@ -1,5 +1,4 @@
 # source: test/e2e/fail_compile/type_errors/plain_call_forwarded_runtime_param_demotion.cst
 # rule: forwarded_runtime_parameter_demotion
-function 'forward_plain' body type mismatch
-expected 'num'
-found 'runtime num'
+function 'forward_plain' body has runtime dependence not reflected in its return type
+runtime parameter

--- a/test/availability_evidence/tyir/availability_validation.patterns
+++ b/test/availability_evidence/tyir/availability_validation.patterns
@@ -2,7 +2,7 @@
 # out-type: tyir
 # rule: call_lifting,runtime_block
 TyFnDecl checked_add(a: num, b: num) -> num
-TyCall(__cst_mod_1__assert): Unit
+TyCall(__cst_mod_1__assert): runtime Unit
 Let static_value: num =
 TyLiteral(3): num
 Let dynamic_value: runtime num =

--- a/test/availability_evidence/tyir/availability_validation.patterns
+++ b/test/availability_evidence/tyir/availability_validation.patterns
@@ -2,7 +2,7 @@
 # out-type: tyir
 # rule: call_lifting,runtime_block
 TyFnDecl checked_add(a: num, b: num) -> num
-TyCall(__cst_mod_1__assert): runtime Unit
+TyCall(__cst_mod_1__assert): Unit
 Let static_value: num =
 TyLiteral(3): num
 Let dynamic_value: runtime num =

--- a/test/availability_evidence/tyir/availability_validation.patterns
+++ b/test/availability_evidence/tyir/availability_validation.patterns
@@ -13,4 +13,6 @@ Let bounded: runtime num =
 TyRuntimeBlock: runtime num
 TyCall(checked_add): runtime num
 TyCall(source): runtime num
-TyLiteral(3): num
+TyCall(checked_add): num
+TyLiteral(1): num
+TyLiteral(2): num


### PR DESCRIPTION
Closes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Canonical availability model: expressions and blocks carry Ct vs Rt availability with optional evidence.
  - Printer/inspector now shows availability annotations (e.g., "[availability: const]" / "[availability: runtime]").

* **Improvements**
  - Availability-aware constant folding and evaluation gating for runtime-only behavior.
  - More precise propagation and joining of availability across control flow, calls, and lowering.
  - Updated diagnostics and documentation to reflect availability semantics.

* **Tests**
  - Expanded unit and integration tests to validate availability derivation, propagation, printing, and folding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->