### PR TITLE
feat: classify direct call residualization and honor runtime barriers

### DIFF
--- a/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/printer.hpp
@@ -87,6 +87,18 @@ inline void indent(std::ostringstream& out, std::size_t level) {
     return " [runtime-authority: " + std::string(runtime_authority_name(authority)) + "]";
 }
 
+[[nodiscard]] inline std::string_view call_residue_name(CallResidue residue) {
+    switch (residue) {
+    case CallResidue::CtEligible: return "ct-eligible";
+    case CallResidue::RuntimeBarrier: return "runtime-barrier";
+    }
+    return "?";
+}
+
+[[nodiscard]] inline std::string call_residue_suffix(CallResidue residue) {
+    return " [call-residue: " + std::string(call_residue_name(residue)) + "]";
+}
+
 [[nodiscard]] inline std::string expr_type_summary(const TyExprPtr& expr) {
     return expr->ty.display() + availability_suffix(expr->availability);
 }
@@ -243,8 +255,9 @@ inline void print_ty_expr(std::ostringstream& out, const TyExprPtr& expr, std::s
                 print_ty_expr(out, node.base, level + 1);
             } else if constexpr (std::is_same_v<N, TyCall>) {
                 indent(out, level);
+                const std::string residue = call_residue_suffix(call_residue_for_expr(*expr, node));
                 out << "TyCall(" << node.fn_name.as_str() << "): " << expr_type_summary(expr)
-                    << "\n";
+                    << residue << "\n";
                 if (!node.generic_args.empty()) {
                     indent(out, level + 1);
                     out << "GenericArgs\n";

--- a/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
+++ b/compiler/cstc_tyir/include/cstc_tyir/tyir.hpp
@@ -622,6 +622,24 @@ struct Availability {
         && !availability.depends_on_runtime_allowed_param;
 }
 
+/// Direct-call residualization outcome for accepted calls.
+///
+/// Rejected calls are represented by lowering errors and therefore never appear
+/// as `TyCall` nodes.
+enum class CallResidue {
+    /// The call may be attempted by const eval.
+    CtEligible,
+    /// The call must remain as a runtime residualization barrier.
+    RuntimeBarrier,
+};
+
+/// Derives accepted direct-call residualization from final value availability.
+[[nodiscard]] inline CallResidue call_residue_from_availability(const Availability& availability) {
+    if (is_ct_available(availability))
+        return CallResidue::CtEligible;
+    return CallResidue::RuntimeBarrier;
+}
+
 /// Single named-field initializer inside a struct construction expression.
 struct TyStructInitField {
     /// Field name.
@@ -694,6 +712,8 @@ struct TyCall {
     std::vector<Ty> generic_args;
     /// Type-annotated argument list (count and types match the function signature).
     std::vector<TyExprPtr> args;
+    /// Direct-call residualization classification after lowering.
+    CallResidue residue = CallResidue::CtEligible;
 };
 
 /// Typed generic function call that still needs more type information.
@@ -840,6 +860,16 @@ inline void set_availability(TyExpr& expr, const Availability& availability) {
     expr.span = span;
     set_availability(expr, availability_join(availability_from_type(expr.ty), availability));
     return std::make_shared<TyExpr>(std::move(expr));
+}
+
+/// Returns the effective residualization classification for a typed call.
+///
+/// The stored call metadata is authoritative for builder-produced TyIR. The
+/// availability fallback keeps hand-built or legacy test nodes conservative.
+[[nodiscard]] inline CallResidue call_residue_for_expr(const TyExpr& expr, const TyCall& call) {
+    if (call.residue == CallResidue::RuntimeBarrier)
+        return CallResidue::RuntimeBarrier;
+    return call_residue_from_availability(expr.availability);
 }
 
 // ─── Statements ──────────────────────────────────────────────────────────────

--- a/compiler/cstc_tyir/tests/tyir_print.cpp
+++ b/compiler/cstc_tyir/tests/tyir_print.cpp
@@ -361,6 +361,7 @@ static void test_print_call_and_struct_init_generic_args() {
 
     const std::string out = format_program(prog);
     assert(contains(out, "TyCall(id): num"));
+    assert(contains(out, "[call-residue: ct-eligible]"));
     assert(contains(out, "GenericArgs"));
     assert(contains(out, "Box<num>"));
 }
@@ -717,8 +718,33 @@ static void test_print_call() {
 
     const std::string out = format_program(prog);
     assert(contains(out, "TyCall(foo): bool"));
+    assert(contains(out, "[call-residue: ct-eligible]"));
     assert(contains(out, "Arg"));
     assert(contains(out, "TyLocal(x): num"));
+}
+
+static void test_print_runtime_barrier_call_residue() {
+    const Symbol foo = Symbol::intern("foo");
+    TyCall call_node;
+    call_node.fn_name = foo;
+    call_node.residue = CallResidue::RuntimeBarrier;
+    auto call = make_ty_expr({}, call_node, ty::num(true), availability_rt());
+
+    auto block = std::make_shared<TyBlock>();
+    block->tail = call;
+    block->ty = ty::num(true);
+
+    TyFnDecl fn;
+    fn.name = Symbol::intern("barrier");
+    fn.return_ty = ty::num(true);
+    fn.body = block;
+
+    TyProgram prog;
+    prog.items.push_back(std::move(fn));
+
+    const std::string out = format_program(prog);
+    assert(contains(out, "TyCall(foo): runtime num [availability: runtime] "));
+    assert(contains(out, "[call-residue: runtime-barrier]"));
 }
 
 static void test_print_runtime_block() {
@@ -851,6 +877,7 @@ int main() {
     test_print_while();
     test_print_for();
     test_print_call();
+    test_print_runtime_barrier_call_residue();
     test_print_runtime_block();
     test_print_availability_summary();
     test_print_let_stmt();

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -968,12 +968,12 @@ struct LowerCtx {
 [[nodiscard]] static tyir::CallResidue direct_call_residue(
     const FnSignature& sig, const std::vector<tyir::TyExprPtr>& args,
     const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
-    if (!exprs_can_fallthrough(args))
-        return tyir::call_residue_from_availability(call_availability);
     if (sig.runtime_authority == tyir::RuntimeAuthority::TrustedExtern)
         return tyir::CallResidue::RuntimeBarrier;
     if (type_has_runtime_dependency(resolved_return_shape))
         return tyir::CallResidue::RuntimeBarrier;
+    if (!exprs_can_fallthrough(args))
+        return tyir::call_residue_from_availability(call_availability);
     for (const tyir::TyExprPtr& arg : args) {
         if (arg != nullptr && arg->availability.kind == tyir::AvailabilityKind::Rt)
             return tyir::CallResidue::RuntimeBarrier;

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -968,6 +968,8 @@ struct LowerCtx {
 [[nodiscard]] static tyir::CallResidue direct_call_residue(
     const FnSignature& sig, const std::vector<tyir::TyExprPtr>& args,
     const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
+    if (!exprs_can_fallthrough(args))
+        return tyir::call_residue_from_availability(call_availability);
     if (sig.runtime_authority == tyir::RuntimeAuthority::TrustedExtern)
         return tyir::CallResidue::RuntimeBarrier;
     if (type_has_runtime_dependency(resolved_return_shape))

--- a/compiler/cstc_tyir_builder/src/builder.cpp
+++ b/compiler/cstc_tyir_builder/src/builder.cpp
@@ -965,6 +965,29 @@ struct LowerCtx {
     return result;
 }
 
+[[nodiscard]] static tyir::CallResidue direct_call_residue(
+    const FnSignature& sig, const std::vector<tyir::TyExprPtr>& args,
+    const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
+    if (sig.runtime_authority == tyir::RuntimeAuthority::TrustedExtern)
+        return tyir::CallResidue::RuntimeBarrier;
+    if (type_has_runtime_dependency(resolved_return_shape))
+        return tyir::CallResidue::RuntimeBarrier;
+    for (const tyir::TyExprPtr& arg : args) {
+        if (arg != nullptr && arg->availability.kind == tyir::AvailabilityKind::Rt)
+            return tyir::CallResidue::RuntimeBarrier;
+    }
+    return tyir::call_residue_from_availability(call_availability);
+}
+
+[[nodiscard]] static tyir::TyCall make_direct_call(
+    cstc::symbol::Symbol fn_name, std::vector<tyir::Ty> generic_args,
+    std::vector<tyir::TyExprPtr> args, const FnSignature& sig,
+    const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
+    tyir::TyCall call{fn_name, std::move(generic_args), std::move(args)};
+    call.residue = direct_call_residue(sig, call.args, resolved_return_shape, call_availability);
+    return call;
+}
+
 [[nodiscard]] static tyir::Ty call_result_type(
     tyir::Ty result_shape, const std::vector<tyir::TyExprPtr>& args, const FnSignature& sig,
     cstc::span::SourceSpan call_span) {
@@ -2064,10 +2087,11 @@ struct ParamReferenceVisitor {
     const tyir::Ty lifted_return_ty =
         tyir::with_availability_projection(resolved_return_ty, call_availability);
 
+    tyir::TyCall resolved_call = make_direct_call(
+        deferred->fn_name, std::move(concrete_generic_args), std::move(resolved_args), sig,
+        resolved_return_shape, call_availability);
     return tyir::make_ty_expr(
-        expr->span,
-        tyir::TyCall{deferred->fn_name, std::move(concrete_generic_args), std::move(resolved_args)},
-        lifted_return_ty, call_availability);
+        expr->span, std::move(resolved_call), lifted_return_ty, call_availability);
 }
 
 [[nodiscard]] static std::expected<cstc::symbol::Symbol, LowerError>
@@ -3303,12 +3327,12 @@ static std::expected<void, LowerError> merge_loop_break_types(
                         sig, lowered_args, resolved_return_shape, expr->span);
                     const tyir::Ty lifted_return_ty =
                         tyir::with_availability_projection(resolved_return_ty, call_availability);
+                    tyir::TyCall resolved_call = make_direct_call(
+                        fn_name, std::move(concrete_generic_args), std::move(lowered_args), sig,
+                        resolved_return_shape, call_availability);
 
                     lowered_expr = tyir::make_ty_expr(
-                        expr->span,
-                        tyir::TyCall{
-                            fn_name, std::move(concrete_generic_args), std::move(lowered_args)},
-                        lifted_return_ty, call_availability);
+                        expr->span, std::move(resolved_call), lifted_return_ty, call_availability);
                 } else {
                     const tyir::Availability call_availability = call_result_availability(
                         sig, lowered_args, resolved_return_shape, expr->span);

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -314,6 +314,8 @@ static void test_call_unreachable_arg_does_not_taint_plain_result() {
     const auto& body = *second_fn(prog).body;
     assert(body.ty == ty::never());
     assert(body.availability.kind == AvailabilityKind::Ct);
+    const TyCall& call = std::get<TyCall>((*body.tail)->node);
+    assert(call.residue == CallResidue::CtEligible);
 }
 
 static void test_plain_call_with_diverging_argument_becomes_never_in_if_branch() {

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -244,8 +244,18 @@ static void test_plain_call_accepts_runtime_argument_and_lifts_result() {
     assert(stmt.ty == ty::num(true));
     assert(stmt.init->ty == ty::num(true));
     const auto& call = std::get<TyCall>(stmt.init->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
     assert(call.args.size() == 1);
     assert(call.args[0]->ty == ty::num(true));
+}
+
+static void test_static_call_is_ct_eligible() {
+    const auto prog = must_lower(
+        "fn add(a: num, b: num) -> num { a + b }"
+        "fn main() -> num { add(1, 2) }");
+    const auto& call = std::get<TyCall>((*second_fn(prog).body->tail)->node);
+    assert(call.residue == CallResidue::CtEligible);
+    assert((*second_fn(prog).body->tail)->availability.kind == AvailabilityKind::Ct);
 }
 
 static void test_ignored_runtime_argument_lifts_direct_call_result() {
@@ -257,9 +267,28 @@ static void test_ignored_runtime_argument_lifts_direct_call_result() {
     assert(stmt.ty == ty::num(true));
     assert(stmt.init->ty == ty::num(true));
     const auto& call = std::get<TyCall>(stmt.init->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
     assert(call.args.size() == 2);
     assert(call.args[0]->ty == ty::num());
     assert(call.args[1]->ty == ty::num(true));
+}
+
+static void test_runtime_result_call_with_ct_args_is_runtime_barrier() {
+    const auto prog = must_lower(
+        "fn one() -> runtime num { 1 }"
+        "fn main() -> runtime num { one() }");
+    const auto& call = std::get<TyCall>((*second_fn(prog).body->tail)->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
+    assert((*second_fn(prog).body->tail)->availability.kind == AvailabilityKind::Rt);
+}
+
+static void test_runtime_extern_call_is_runtime_barrier() {
+    const auto prog = must_lower(
+        "runtime extern \"lang\" fn poll() -> num;"
+        "fn main() -> runtime num { poll() }");
+    const auto& call = std::get<TyCall>((*first_fn(prog).body->tail)->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
+    assert(call.fn_name == Symbol::intern("poll"));
 }
 
 static void test_ignored_runtime_argument_prevents_direct_call_result_demotion() {
@@ -1758,7 +1787,10 @@ int main() {
     test_logical();
     test_runtime_argument_promotion();
     test_plain_call_accepts_runtime_argument_and_lifts_result();
+    test_static_call_is_ct_eligible();
     test_ignored_runtime_argument_lifts_direct_call_result();
+    test_runtime_result_call_with_ct_args_is_runtime_barrier();
+    test_runtime_extern_call_is_runtime_barrier();
     test_ignored_runtime_argument_prevents_direct_call_result_demotion();
     test_plain_call_lifted_result_still_prevents_return_demotion();
     test_call_unreachable_arg_does_not_taint_plain_result();

--- a/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
+++ b/compiler/cstc_tyir_builder/tests/lower_exprs.cpp
@@ -309,13 +309,35 @@ static void test_plain_call_lifted_result_still_prevents_return_demotion() {
 
 static void test_call_unreachable_arg_does_not_taint_plain_result() {
     const auto prog = must_lower(
-        "runtime fn source(left: num, right: num) -> num { right }"
+        "fn source(left: num, right: num) -> num { right }"
         "fn f() -> num { source((return 1), runtime { 2 }) }");
     const auto& body = *second_fn(prog).body;
     assert(body.ty == ty::never());
     assert(body.availability.kind == AvailabilityKind::Ct);
     const TyCall& call = std::get<TyCall>((*body.tail)->node);
     assert(call.residue == CallResidue::CtEligible);
+}
+
+static void test_runtime_result_call_with_unreachable_arg_stays_runtime_barrier() {
+    const auto prog = must_lower(
+        "fn sink(value: num) -> runtime num { value }"
+        "fn f() -> runtime num { sink((return 1)) }");
+    const auto& body = *second_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+    const TyCall& call = std::get<TyCall>((*body.tail)->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
+}
+
+static void test_runtime_extern_call_with_unreachable_arg_stays_runtime_barrier() {
+    const auto prog = must_lower(
+        "runtime extern \"lang\" fn sink(value: num);"
+        "fn f() -> num { sink((return 1)) }");
+    const auto& body = *first_fn(prog).body;
+    assert(body.ty == ty::never());
+    assert(body.availability.kind == AvailabilityKind::Ct);
+    const TyCall& call = std::get<TyCall>((*body.tail)->node);
+    assert(call.residue == CallResidue::RuntimeBarrier);
 }
 
 static void test_plain_call_with_diverging_argument_becomes_never_in_if_branch() {
@@ -1796,6 +1818,8 @@ int main() {
     test_ignored_runtime_argument_prevents_direct_call_result_demotion();
     test_plain_call_lifted_result_still_prevents_return_demotion();
     test_call_unreachable_arg_does_not_taint_plain_result();
+    test_runtime_result_call_with_unreachable_arg_stays_runtime_barrier();
+    test_runtime_extern_call_with_unreachable_arg_stays_runtime_barrier();
     test_plain_call_with_diverging_argument_becomes_never_in_if_branch();
     test_unused_runtime_let_taints_plain_result_function();
     test_runtime_expression_statement_taints_plain_result_function();

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -12,6 +12,7 @@ namespace cstc::tyir_interp::detail {
 using tyir::common_type;
 using tyir::compatible;
 using tyir::matches_type_shape;
+using tyir::type_has_runtime_dependency;
 
 ValuePtr make_num(double value) {
     auto out = std::make_shared<Value>();
@@ -259,6 +260,8 @@ using GenericParamSet = std::unordered_set<Symbol, SymbolHash>;
 }
 
 [[nodiscard]] static bool has_runtime_barrier(const tyir::TyExpr& expr) {
+    if (const auto* call = std::get_if<tyir::TyCall>(&expr.node))
+        return tyir::call_residue_for_expr(expr, *call) == tyir::CallResidue::RuntimeBarrier;
     return expr.availability.kind == tyir::AvailabilityKind::Rt;
 }
 
@@ -540,6 +543,90 @@ static void recompute_block_availability(tyir::TyBlock& block) {
             return true;
     }
     return false;
+}
+
+[[nodiscard]] static std::vector<tyir::Availability>
+    call_arg_availabilities(const std::vector<tyir::TyExprPtr>& args) {
+    std::vector<tyir::Availability> availabilities;
+    availabilities.reserve(args.size());
+    for (const tyir::TyExprPtr& arg : args)
+        availabilities.push_back(arg != nullptr ? arg->availability : tyir::availability_ct());
+    return availabilities;
+}
+
+[[nodiscard]] static tyir::Availability call_result_availability(
+    tyir::RuntimeAuthority runtime_authority, const tyir::AvailabilityExpr& result_availability,
+    const std::optional<tyir::TyRuntimeEvidence>& internal_runtime_evidence,
+    const std::vector<cstc::ast::GenericParam>& generic_params,
+    const std::vector<tyir::TyExprPtr>& args, const tyir::Ty& resolved_return_shape,
+    SourceSpan call_span) {
+    tyir::Availability result =
+        tyir::availability_expr_substitute(result_availability, call_arg_availabilities(args));
+    if (type_depends_on_generic_params(
+            resolved_return_shape, make_generic_param_set(generic_params))) {
+        for (const tyir::TyExprPtr& arg : args) {
+            if (arg != nullptr)
+                result = tyir::availability_join(result, availability_of_expr(arg));
+        }
+    }
+    if (type_has_runtime_dependency(resolved_return_shape)) {
+        const char* reason = "runtime-result call";
+        if (runtime_authority == tyir::RuntimeAuthority::TrustedExtern)
+            reason = "trusted runtime extern";
+        result = tyir::availability_join(
+            result, tyir::availability_rt(tyir::TyRuntimeEvidence{call_span, reason}));
+    } else if (result.kind == tyir::AvailabilityKind::Rt && !result.evidence.has_value()) {
+        result = tyir::availability_join(result, tyir::availability_rt(internal_runtime_evidence));
+    }
+    return result;
+}
+
+[[nodiscard]] static tyir::Availability call_result_availability(
+    const tyir::TyFnDecl& decl, const std::vector<tyir::TyExprPtr>& args,
+    const tyir::Ty& resolved_return_shape, SourceSpan call_span) {
+    return call_result_availability(
+        decl.runtime_authority, decl.result_availability, decl.internal_runtime_evidence,
+        decl.generic_params, args, resolved_return_shape, call_span);
+}
+
+[[nodiscard]] static tyir::Availability call_result_availability(
+    const tyir::TyExternFnDecl& decl, const std::vector<tyir::TyExprPtr>& args,
+    const tyir::Ty& resolved_return_shape, SourceSpan call_span) {
+    return call_result_availability(
+        decl.runtime_authority, decl.result_availability, decl.internal_runtime_evidence, {}, args,
+        resolved_return_shape, call_span);
+}
+
+[[nodiscard]] static tyir::CallResidue direct_call_residue(
+    tyir::RuntimeAuthority runtime_authority, const std::vector<tyir::TyExprPtr>& args,
+    const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
+    if (runtime_authority == tyir::RuntimeAuthority::TrustedExtern)
+        return tyir::CallResidue::RuntimeBarrier;
+    if (type_has_runtime_dependency(resolved_return_shape))
+        return tyir::CallResidue::RuntimeBarrier;
+    for (const tyir::TyExprPtr& arg : args) {
+        if (arg != nullptr && arg->availability.kind == tyir::AvailabilityKind::Rt)
+            return tyir::CallResidue::RuntimeBarrier;
+    }
+    return tyir::call_residue_from_availability(call_availability);
+}
+
+[[nodiscard]] static tyir::TyCall classify_call(
+    tyir::TyCall call, tyir::RuntimeAuthority runtime_authority,
+    const tyir::Ty& resolved_return_shape, const tyir::Availability& call_availability) {
+    const tyir::Ty& shape = resolved_return_shape;
+    const tyir::Availability& availability = call_availability;
+    call.residue = direct_call_residue(runtime_authority, call.args, shape, availability);
+    return call;
+}
+
+[[nodiscard]] static tyir::TyExprPtr make_classified_call_expr(
+    SourceSpan span, tyir::TyCall call, const tyir::Ty& ty,
+    const tyir::Availability& availability) {
+    auto expr = tyir::make_ty_expr(span, std::move(call), ty, availability);
+    auto& stored_call = std::get<tyir::TyCall>(expr->node);
+    stored_call.residue = tyir::call_residue_from_availability(expr->availability);
+    return expr;
 }
 
 [[nodiscard]] static ConstraintEvalResult generic_substitution_dependency_result() {
@@ -1498,7 +1585,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     rewritten.generic_args.push_back(apply_substitution(generic_arg, subst));
                 for (tyir::TyExprPtr& arg : rewritten.args)
                     arg = apply_substitution(arg, subst);
-                return tyir::make_ty_expr(
+                return make_classified_call_expr(
                     expr->span, std::move(rewritten), rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyDeclProbe>) {
                 tyir::TyDeclProbe rewritten = node;
@@ -1530,12 +1617,10 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     assert(generic_arg.has_value());
                     concrete_generic_args.push_back(*generic_arg);
                 }
-                return tyir::make_ty_expr(
-                    expr->span,
-                    tyir::TyCall{
-                        rewritten.fn_name, std::move(concrete_generic_args),
-                        std::move(rewritten.args)},
-                    rewritten_ty, expr->availability);
+                tyir::TyCall call{
+                    rewritten.fn_name, std::move(concrete_generic_args), std::move(rewritten.args)};
+                return make_classified_call_expr(
+                    expr->span, std::move(call), rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
                 return tyir::make_ty_expr(
                     expr->span, tyir::TyRuntimeBlock{apply_substitution(node.body, subst)},
@@ -2888,6 +2973,10 @@ std::expected<ValuePtr, EvalError> eval_lang_intrinsic(
                     const tyir::TyFnDecl& fn = *fn_it->second;
                     if (fn.return_ty.is_runtime || fn.is_runtime)
                         return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
+                    if (tyir::call_residue_for_expr(*expr, node)
+                        == tyir::CallResidue::RuntimeBarrier) {
+                        return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
+                    }
                     if (!generic_args_depend_on_generic_params(
                             node.generic_args, ctx.generic_params)) {
                         const auto constraint_status = enforce_constraints(
@@ -2957,6 +3046,8 @@ std::expected<ValuePtr, EvalError> eval_lang_intrinsic(
 
                 const tyir::TyExternFnDecl& decl = *ext_it->second;
                 if (decl.return_ty.is_runtime || decl.is_runtime)
+                    return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
+                if (tyir::call_residue_for_expr(*expr, node) == tyir::CallResidue::RuntimeBarrier)
                     return EvalState::blocked(EvalState::BlockedReason::RuntimeOnly);
                 if (decl.abi.as_str() != std::string_view{"lang"})
                     return make_error(
@@ -3684,8 +3775,6 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
             }
 
             if constexpr (std::is_same_v<Node, tyir::TyCall>) {
-                if (!tyir::is_ct_available(expr))
-                    return expr;
                 std::vector<tyir::TyExprPtr> args;
                 args.reserve(node.args.size());
                 for (const tyir::TyExprPtr& arg : node.args) {
@@ -3694,10 +3783,92 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                         return std::unexpected(std::move(folded_arg.error()));
                     args.push_back(*folded_arg);
                 }
+                tyir::TyCall call{node.fn_name, node.generic_args, std::move(args), node.residue};
+                const bool original_call_is_runtime_barrier =
+                    tyir::call_residue_for_expr(*expr, node) == tyir::CallResidue::RuntimeBarrier;
+                if (original_call_is_runtime_barrier) {
+                    call.residue = tyir::CallResidue::RuntimeBarrier;
+                    return tyir::make_ty_expr(
+                        expr->span, std::move(call), expr->ty, expr->availability);
+                }
+
+                if (const auto fn_it = program.fns.find(node.fn_name); fn_it != program.fns.end()) {
+                    EvalContext ctx{
+                        program,
+                        {},
+                        kDefaultEvalStepBudget,
+                        kDefaultEvalCallDepth,
+                        {},
+                        std::make_shared<ConstraintEvalState>(),
+                    };
+                    const std::string_view fn_name = fn_it->second->name.as_str();
+                    const SourceSpan span = expr->span;
+                    const std::size_t expected = fn_it->second->params.size();
+                    const std::size_t actual = call.args.size();
+                    auto arity = require_call_arity(ctx, span, fn_name, expected, actual);
+                    if (!arity)
+                        return std::unexpected(std::move(arity.error()));
+
+                    tyir::Ty resolved_return_shape = fn_it->second->return_ty;
+                    if (!node.generic_args.empty()) {
+                        const TypeSubstitution substitution =
+                            build_substitution(fn_it->second->generic_params, node.generic_args);
+                        resolved_return_shape =
+                            apply_substitution(resolved_return_shape, substitution);
+                    }
+                    const tyir::Availability call_availability = call_result_availability(
+                        *fn_it->second, call.args, resolved_return_shape, expr->span);
+                    call = classify_call(
+                        std::move(call), fn_it->second->runtime_authority, resolved_return_shape,
+                        call_availability);
+                    const tyir::Ty call_ty = tyir::with_availability_projection(
+                        resolved_return_shape, call_availability);
+                    if (call.residue == tyir::CallResidue::RuntimeBarrier) {
+                        return tyir::make_ty_expr(
+                            expr->span, std::move(call), call_ty, call_availability);
+                    }
+                    return maybe_fold_constant(
+                        tyir::make_ty_expr(expr->span, std::move(call), call_ty, call_availability),
+                        program, env, generic_params);
+                }
+
+                if (const auto ext_it = program.extern_fns.find(node.fn_name);
+                    ext_it != program.extern_fns.end()) {
+                    EvalContext ctx{
+                        program,
+                        {},
+                        kDefaultEvalStepBudget,
+                        kDefaultEvalCallDepth,
+                        {},
+                        std::make_shared<ConstraintEvalState>(),
+                    };
+                    const std::string_view fn_name = ext_it->second->name.as_str();
+                    const SourceSpan span = expr->span;
+                    const std::size_t expected = ext_it->second->params.size();
+                    const std::size_t actual = call.args.size();
+                    auto arity = require_call_arity(ctx, span, fn_name, expected, actual);
+                    if (!arity)
+                        return std::unexpected(std::move(arity.error()));
+
+                    const tyir::Ty resolved_return_shape = ext_it->second->return_ty;
+                    const tyir::Availability call_availability = call_result_availability(
+                        *ext_it->second, call.args, resolved_return_shape, expr->span);
+                    call = classify_call(
+                        std::move(call), ext_it->second->runtime_authority, resolved_return_shape,
+                        call_availability);
+                    const tyir::Ty call_ty = tyir::with_availability_projection(
+                        resolved_return_shape, call_availability);
+                    if (call.residue == tyir::CallResidue::RuntimeBarrier) {
+                        return tyir::make_ty_expr(
+                            expr->span, std::move(call), call_ty, call_availability);
+                    }
+                    return maybe_fold_constant(
+                        tyir::make_ty_expr(expr->span, std::move(call), call_ty, call_availability),
+                        program, env, generic_params);
+                }
+
                 return maybe_fold_constant(
-                    tyir::make_ty_expr(
-                        expr->span, tyir::TyCall{node.fn_name, node.generic_args, std::move(args)},
-                        expr->ty, expr->availability),
+                    tyir::make_ty_expr(expr->span, std::move(call), expr->ty, expr->availability),
                     program, env, generic_params);
             }
 

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -3831,13 +3831,6 @@ std::expected<tyir::TyExprPtr, EvalError> value_to_expr(
                     args.push_back(*folded_arg);
                 }
                 tyir::TyCall call{node.fn_name, node.generic_args, std::move(args), node.residue};
-                const bool original_call_is_runtime_barrier =
-                    tyir::call_residue_for_expr(*expr, node) == tyir::CallResidue::RuntimeBarrier;
-                if (original_call_is_runtime_barrier) {
-                    call.residue = tyir::CallResidue::RuntimeBarrier;
-                    return tyir::make_ty_expr(
-                        expr->span, std::move(call), expr->ty, expr->availability);
-                }
 
                 if (const auto fn_it = program.fns.find(node.fn_name); fn_it != program.fns.end()) {
                     EvalContext ctx{

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -623,10 +623,7 @@ static void recompute_block_availability(tyir::TyBlock& block) {
 [[nodiscard]] static tyir::TyExprPtr make_classified_call_expr(
     SourceSpan span, tyir::TyCall call, const tyir::Ty& ty,
     const tyir::Availability& availability) {
-    auto expr = tyir::make_ty_expr(span, std::move(call), ty, availability);
-    auto& stored_call = std::get<tyir::TyCall>(expr->node);
-    stored_call.residue = tyir::call_residue_from_availability(expr->availability);
-    return expr;
+    return tyir::make_ty_expr(span, std::move(call), ty, availability);
 }
 
 [[nodiscard]] static ConstraintEvalResult generic_substitution_dependency_result() {

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -554,6 +554,10 @@ static void recompute_block_availability(tyir::TyBlock& block) {
     return availabilities;
 }
 
+[[nodiscard]] static TypeSubstitution build_substitution(
+    const std::vector<cstc::ast::GenericParam>& generic_params,
+    const std::vector<tyir::Ty>& generic_args);
+
 [[nodiscard]] static tyir::Availability call_result_availability(
     tyir::RuntimeAuthority runtime_authority, const tyir::AvailabilityExpr& result_availability,
     const std::optional<tyir::TyRuntimeEvidence>& internal_runtime_evidence,
@@ -624,6 +628,45 @@ static void recompute_block_availability(tyir::TyBlock& block) {
     SourceSpan span, tyir::TyCall call, const tyir::Ty& ty,
     const tyir::Availability& availability) {
     return tyir::make_ty_expr(span, std::move(call), ty, availability);
+}
+
+[[nodiscard]] static tyir::TyExprPtr make_materialized_call_expr(
+    SourceSpan span, tyir::TyCall call, const tyir::Ty& ty, const tyir::Availability& availability,
+    const ProgramView* program) {
+    if (program == nullptr)
+        return make_classified_call_expr(span, std::move(call), ty, availability);
+
+    if (const auto fn_it = program->fns.find(call.fn_name); fn_it != program->fns.end()) {
+        const tyir::TyFnDecl& fn = *fn_it->second;
+        tyir::Ty resolved_return_shape = fn.return_ty;
+        if (!call.generic_args.empty()) {
+            const TypeSubstitution substitution =
+                build_substitution(fn.generic_params, call.generic_args);
+            resolved_return_shape = apply_substitution(resolved_return_shape, substitution);
+        }
+        const tyir::Availability call_availability =
+            call_result_availability(fn, call.args, resolved_return_shape, span);
+        call = classify_call(
+            std::move(call), fn.runtime_authority, resolved_return_shape, call_availability);
+        return make_classified_call_expr(
+            span, std::move(call), tyir::with_availability_projection(ty, call_availability),
+            call_availability);
+    }
+
+    if (const auto ext_it = program->extern_fns.find(call.fn_name);
+        ext_it != program->extern_fns.end()) {
+        const tyir::TyExternFnDecl& decl = *ext_it->second;
+        const tyir::Ty resolved_return_shape = decl.return_ty;
+        const tyir::Availability call_availability =
+            call_result_availability(decl, call.args, resolved_return_shape, span);
+        call = classify_call(
+            std::move(call), decl.runtime_authority, resolved_return_shape, call_availability);
+        return make_classified_call_expr(
+            span, std::move(call), tyir::with_availability_projection(ty, call_availability),
+            call_availability);
+    }
+
+    return make_classified_call_expr(span, std::move(call), ty, availability);
 }
 
 [[nodiscard]] static ConstraintEvalResult generic_substitution_dependency_result() {
@@ -1483,22 +1526,24 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
         expr->node);
 }
 
-[[nodiscard]] static tyir::TyExprPtr
-    apply_substitution(const tyir::TyExprPtr& expr, const TypeSubstitution& subst);
+[[nodiscard]] static tyir::TyExprPtr apply_substitution(
+    const tyir::TyExprPtr& expr, const TypeSubstitution& subst,
+    const ProgramView* program = nullptr);
 
-[[nodiscard]] static tyir::TyBlockPtr
-    apply_substitution(const tyir::TyBlockPtr& block, const TypeSubstitution& subst);
+[[nodiscard]] static tyir::TyBlockPtr apply_substitution(
+    const tyir::TyBlockPtr& block, const TypeSubstitution& subst,
+    const ProgramView* program = nullptr);
 
-[[nodiscard]] static tyir::TyForInit
-    apply_substitution(const tyir::TyForInit& init, const TypeSubstitution& subst) {
+[[nodiscard]] static tyir::TyForInit apply_substitution(
+    const tyir::TyForInit& init, const TypeSubstitution& subst, const ProgramView* program) {
     tyir::TyForInit rewritten = init;
     rewritten.ty = apply_substitution(init.ty, subst);
-    rewritten.init = apply_substitution(init.init, subst);
+    rewritten.init = apply_substitution(init.init, subst, program);
     return rewritten;
 }
 
-[[nodiscard]] static tyir::TyBlockPtr
-    apply_substitution(const tyir::TyBlockPtr& block, const TypeSubstitution& subst) {
+[[nodiscard]] static tyir::TyBlockPtr apply_substitution(
+    const tyir::TyBlockPtr& block, const TypeSubstitution& subst, const ProgramView* program) {
     if (block == nullptr)
         return nullptr;
 
@@ -1516,23 +1561,24 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                             node.discard,
                             node.name,
                             apply_substitution(node.ty, subst),
-                            apply_substitution(node.init, subst),
+                            apply_substitution(node.init, subst, program),
                             node.span,
                         };
                     } else {
-                        return tyir::TyExprStmt{apply_substitution(node.expr, subst), node.span};
+                        return tyir::TyExprStmt{
+                            apply_substitution(node.expr, subst, program), node.span};
                     }
                 },
                 stmt));
     }
     if (block->tail.has_value())
-        rewritten->tail = apply_substitution(*block->tail, subst);
+        rewritten->tail = apply_substitution(*block->tail, subst, program);
     recompute_block_availability(*rewritten);
     return rewritten;
 }
 
-[[nodiscard]] static tyir::TyExprPtr
-    apply_substitution(const tyir::TyExprPtr& expr, const TypeSubstitution& subst) {
+[[nodiscard]] static tyir::TyExprPtr apply_substitution(
+    const tyir::TyExprPtr& expr, const TypeSubstitution& subst, const ProgramView* program) {
     if (expr == nullptr)
         return nullptr;
 
@@ -1552,27 +1598,29 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                 for (const tyir::Ty& generic_arg : node.generic_args)
                     rewritten.generic_args.push_back(apply_substitution(generic_arg, subst));
                 for (tyir::TyStructInitField& field : rewritten.fields)
-                    field.value = apply_substitution(field.value, subst);
+                    field.value = apply_substitution(field.value, subst, program);
                 return tyir::make_ty_expr(expr->span, std::move(rewritten), rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyBorrow>) {
                 return tyir::make_ty_expr(
-                    expr->span, tyir::TyBorrow{apply_substitution(node.rhs, subst)}, rewritten_ty);
+                    expr->span, tyir::TyBorrow{apply_substitution(node.rhs, subst, program)},
+                    rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyUnary>) {
                 return tyir::make_ty_expr(
-                    expr->span, tyir::TyUnary{node.op, apply_substitution(node.rhs, subst)},
+                    expr->span,
+                    tyir::TyUnary{node.op, apply_substitution(node.rhs, subst, program)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyBinary>) {
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyBinary{
-                        node.op, apply_substitution(node.lhs, subst),
-                        apply_substitution(node.rhs, subst)},
+                        node.op, apply_substitution(node.lhs, subst, program),
+                        apply_substitution(node.rhs, subst, program)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyFieldAccess>) {
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyFieldAccess{
-                        apply_substitution(node.base, subst), node.field, node.use_kind},
+                        apply_substitution(node.base, subst, program), node.field, node.use_kind},
                     rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyCall>) {
                 tyir::TyCall rewritten = node;
@@ -1581,13 +1629,13 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                 for (const tyir::Ty& generic_arg : node.generic_args)
                     rewritten.generic_args.push_back(apply_substitution(generic_arg, subst));
                 for (tyir::TyExprPtr& arg : rewritten.args)
-                    arg = apply_substitution(arg, subst);
+                    arg = apply_substitution(arg, subst, program);
                 return make_classified_call_expr(
                     expr->span, std::move(rewritten), rewritten_ty, expr->availability);
             } else if constexpr (std::is_same_v<Node, tyir::TyDeclProbe>) {
                 tyir::TyDeclProbe rewritten = node;
                 if (rewritten.expr.has_value())
-                    rewritten.expr = apply_substitution(*rewritten.expr, subst);
+                    rewritten.expr = apply_substitution(*rewritten.expr, subst, program);
                 return tyir::make_ty_expr(expr->span, std::move(rewritten), rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyDeferredGenericCall>) {
                 tyir::TyDeferredGenericCall rewritten = node;
@@ -1603,7 +1651,7 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     rewritten.generic_args.push_back(apply_substitution(*generic_arg, subst));
                 }
                 for (tyir::TyExprPtr& arg : rewritten.args)
-                    arg = apply_substitution(arg, subst);
+                    arg = apply_substitution(arg, subst, program);
                 if (!fully_resolved)
                     return tyir::make_ty_expr(
                         expr->span, std::move(rewritten), rewritten_ty, expr->availability);
@@ -1616,61 +1664,63 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                 }
                 tyir::TyCall call{
                     rewritten.fn_name, std::move(concrete_generic_args), std::move(rewritten.args)};
-                return make_classified_call_expr(
-                    expr->span, std::move(call), rewritten_ty, expr->availability);
+                return make_materialized_call_expr(
+                    expr->span, std::move(call), rewritten_ty, expr->availability, program);
             } else if constexpr (std::is_same_v<Node, tyir::TyRuntimeBlock>) {
                 return tyir::make_ty_expr(
-                    expr->span, tyir::TyRuntimeBlock{apply_substitution(node.body, subst)},
+                    expr->span, tyir::TyRuntimeBlock{apply_substitution(node.body, subst, program)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyBlockPtr>) {
                 return tyir::make_ty_expr(
-                    expr->span, apply_substitution(node, subst), rewritten_ty);
+                    expr->span, apply_substitution(node, subst, program), rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyIf>) {
                 std::optional<tyir::TyExprPtr> else_branch;
                 if (node.else_branch.has_value())
-                    else_branch = apply_substitution(*node.else_branch, subst);
+                    else_branch = apply_substitution(*node.else_branch, subst, program);
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyIf{
-                        apply_substitution(node.condition, subst),
-                        apply_substitution(node.then_block, subst), std::move(else_branch)},
+                        apply_substitution(node.condition, subst, program),
+                        apply_substitution(node.then_block, subst, program),
+                        std::move(else_branch)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyLoop>) {
                 return tyir::make_ty_expr(
-                    expr->span, tyir::TyLoop{apply_substitution(node.body, subst)}, rewritten_ty);
+                    expr->span, tyir::TyLoop{apply_substitution(node.body, subst, program)},
+                    rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyWhile>) {
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyWhile{
-                        apply_substitution(node.condition, subst),
-                        apply_substitution(node.body, subst)},
+                        apply_substitution(node.condition, subst, program),
+                        apply_substitution(node.body, subst, program)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyFor>) {
                 std::optional<tyir::TyForInit> init;
                 if (node.init.has_value())
-                    init = apply_substitution(*node.init, subst);
+                    init = apply_substitution(*node.init, subst, program);
                 std::optional<tyir::TyExprPtr> condition;
                 if (node.condition.has_value())
-                    condition = apply_substitution(*node.condition, subst);
+                    condition = apply_substitution(*node.condition, subst, program);
                 std::optional<tyir::TyExprPtr> step;
                 if (node.step.has_value())
-                    step = apply_substitution(*node.step, subst);
+                    step = apply_substitution(*node.step, subst, program);
                 return tyir::make_ty_expr(
                     expr->span,
                     tyir::TyFor{
                         std::move(init), std::move(condition), std::move(step),
-                        apply_substitution(node.body, subst)},
+                        apply_substitution(node.body, subst, program)},
                     rewritten_ty);
             } else if constexpr (std::is_same_v<Node, tyir::TyBreak>) {
                 std::optional<tyir::TyExprPtr> value;
                 if (node.value.has_value())
-                    value = apply_substitution(*node.value, subst);
+                    value = apply_substitution(*node.value, subst, program);
                 return tyir::make_ty_expr(
                     expr->span, tyir::TyBreak{std::move(value)}, rewritten_ty);
             } else {
                 std::optional<tyir::TyExprPtr> value;
                 if (node.value.has_value())
-                    value = apply_substitution(*node.value, subst);
+                    value = apply_substitution(*node.value, subst, program);
                 return tyir::make_ty_expr(
                     expr->span, tyir::TyReturn{std::move(value)}, rewritten_ty);
             }
@@ -1846,7 +1896,7 @@ ConstraintEvalResult evaluate_constraint(
     const tyir::TyExprPtr& expr, const TypeSubstitution& substitution, const ProgramView& program,
     std::vector<EvalStackFrame> stack,
     const std::shared_ptr<ConstraintEvalState>& constraint_state) {
-    const tyir::TyExprPtr substituted = apply_substitution(expr, substitution);
+    const tyir::TyExprPtr substituted = apply_substitution(expr, substitution, &program);
     ConstEnv env;
     env.push();
     EvalContext ctx{

--- a/compiler/cstc_tyir_interp/src/interp.cpp
+++ b/compiler/cstc_tyir_interp/src/interp.cpp
@@ -1630,8 +1630,8 @@ static void seed_probe_external_locals(const tyir::TyExprPtr& expr, ProbeOwnersh
                     rewritten.generic_args.push_back(apply_substitution(generic_arg, subst));
                 for (tyir::TyExprPtr& arg : rewritten.args)
                     arg = apply_substitution(arg, subst, program);
-                return make_classified_call_expr(
-                    expr->span, std::move(rewritten), rewritten_ty, expr->availability);
+                return make_materialized_call_expr(
+                    expr->span, std::move(rewritten), rewritten_ty, expr->availability, program);
             } else if constexpr (std::is_same_v<Node, tyir::TyDeclProbe>) {
                 tyir::TyDeclProbe rewritten = node;
                 if (rewritten.expr.has_value())

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -279,8 +279,36 @@ fn main() -> runtime num {
     assert(tail->ty == ty::num(true));
     const TyCall& call = require_call(tail);
     assert(call.fn_name == Symbol::intern("inc"));
+    assert(call.residue == CallResidue::RuntimeBarrier);
     assert(call.args.size() == 1);
     assert(call.args[0]->ty == ty::num(true));
+}
+
+static void test_ignored_runtime_argument_keeps_same_callee_barrier() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+runtime fn source() -> num {
+    41
+}
+
+fn first(a: num, b: num) -> num {
+    a
+}
+
+fn main() -> runtime num {
+    first(1 + 2, source())
+}
+)");
+
+    const TyExprPtr& tail = require_tail(find_fn(program, "main"));
+    assert(tail->ty == ty::num(true));
+    const TyCall& call = require_call(tail);
+    assert(call.fn_name == Symbol::intern("first"));
+    assert(call.residue == CallResidue::RuntimeBarrier);
+    assert(call.args.size() == 2);
+    const TyLiteral& folded_arg = require_literal(call.args[0]);
+    assert(folded_arg.symbol.as_str() == std::string_view{"3"});
+    assert(call.args[1]->ty == ty::num(true));
 }
 
 static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
@@ -322,6 +350,7 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
     assert(tail->availability.evidence.has_value());
     assert(tail->availability.evidence->reason == "runtime-result call");
     const TyCall& call = require_call(tail);
+    assert(call.residue == CallResidue::RuntimeBarrier);
     assert(call.fn_name == Symbol::intern("id"));
     assert(call.generic_args.size() == 1);
     assert(call.args.size() == 1);
@@ -368,9 +397,29 @@ static void test_rt_available_call_with_foldable_argument_remains_in_tyir() {
     assert(tail->availability.evidence.has_value());
     assert(tail->availability.evidence->reason == "runtime-result call");
     const TyCall& call = require_call(tail);
+    assert(call.residue == CallResidue::RuntimeBarrier);
     assert(call.fn_name == id_name);
     assert(call.args.size() == 1);
-    assert(std::holds_alternative<TyBinary>(call.args.front()->node));
+    const TyLiteral& folded_arg = require_literal(call.args.front());
+    assert(folded_arg.kind == TyLiteral::Kind::Num);
+    assert(folded_arg.symbol.as_str() == std::string_view{"3"});
+}
+
+static void test_runtime_extern_call_remains_runtime_barrier() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+runtime extern "lang" fn poll() -> num;
+
+fn main() -> runtime num {
+    poll()
+}
+)");
+
+    const TyExprPtr& tail = require_tail(find_fn(program, "main"));
+    const TyCall& call = require_call(tail);
+    assert(call.fn_name == Symbol::intern("poll"));
+    assert(call.residue == CallResidue::RuntimeBarrier);
+    assert(tail->availability.kind == AvailabilityKind::Rt);
 }
 
 static void test_null_evidence_rt_call_remains_in_tyir() {
@@ -601,8 +650,16 @@ fn main() {
 static void test_folded_if_recomputes_availability_after_erasing_runtime_branch() {
     SymbolSession session;
     const auto program = must_fold(R"(
+fn source() -> runtime num {
+    2
+}
+
 fn choose(value: num) -> num {
     if true { 1 } else { value }
+}
+
+fn choose_call() -> runtime num {
+    if true { 1 } else { source() }
 }
 )");
 
@@ -613,6 +670,14 @@ fn choose(value: num) -> num {
     assert(literal.symbol.as_str() == std::string_view{"1"});
     assert(is_ct_available(*tail));
     assert(is_ct_available(*choose.body));
+
+    const TyFnDecl& choose_call = find_fn(program, "choose_call");
+    const TyExprPtr& call_tail = require_tail(choose_call);
+    const TyLiteral& call_literal = require_literal(call_tail);
+    assert(call_literal.kind == TyLiteral::Kind::Num);
+    assert(call_literal.symbol.as_str() == std::string_view{"1"});
+    assert(is_ct_available(*call_tail));
+    assert(is_ct_available(*choose_call.body));
 }
 
 static void test_folded_for_recomputes_availability_with_reachability() {
@@ -910,8 +975,9 @@ fn main() {
     assert(print_call.args.size() == 1);
     assert(std::holds_alternative<TyBorrow>(print_call.args[0]->node));
     const auto& borrow = std::get<TyBorrow>(print_call.args[0]->node);
-    assert(std::holds_alternative<LocalRef>(borrow.rhs->node));
-    assert(std::get<LocalRef>(borrow.rhs->node).name == Symbol::intern("rendered"));
+    const TyLiteral& folded_rhs = require_literal(borrow.rhs);
+    assert(folded_rhs.kind == TyLiteral::Kind::OwnedStr);
+    assert(folded_rhs.symbol.as_str() == std::string_view{"\"42\""});
 }
 
 static void test_borrow_preserves_folded_rhs_when_ref_cannot_materialize() {
@@ -935,7 +1001,9 @@ fn main() {
     assert(std::holds_alternative<TyBorrow>(sink_call.args[0]->node));
 
     const auto& borrow = std::get<TyBorrow>(sink_call.args[0]->node);
-    assert(std::holds_alternative<TyBinary>(borrow.rhs->node));
+    const TyLiteral& folded_rhs = require_literal(borrow.rhs);
+    assert(folded_rhs.kind == TyLiteral::Kind::Num);
+    assert(folded_rhs.symbol.as_str() == std::string_view{"3"});
 }
 
 static void test_runtime_intrinsic_call_is_preserved() {
@@ -3328,8 +3396,10 @@ int main() {
     test_const_function_call_folds_to_literal();
     test_runtime_call_remains_in_tyir();
     test_plain_call_with_runtime_argument_remains_in_tyir();
+    test_ignored_runtime_argument_keeps_same_callee_barrier();
     test_runtime_result_call_with_ct_argument_remains_in_tyir();
     test_rt_available_call_with_foldable_argument_remains_in_tyir();
+    test_runtime_extern_call_remains_runtime_barrier();
     test_null_evidence_rt_call_remains_in_tyir();
     test_runtime_block_folds_pure_inner_expression();
     test_runtime_block_preserves_runtime_call_boundary();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -3225,6 +3225,88 @@ static void test_decl_generic_runtime_result_call_fails_after_substitution() {
     assert(folded.error().message.find("function 'wrapper'") != std::string::npos);
 }
 
+static void test_decl_generic_trusted_extern_call_preserves_barrier_after_substitution() {
+    SymbolSession session;
+    const Symbol constraint_name = Symbol::intern("Constraint");
+    const Symbol trusted_fn = Symbol::intern("trusted_constraint");
+    const Symbol wrapper_name = Symbol::intern("wrapper");
+    const Symbol generic_name = Symbol::intern("T");
+    const Ty constraint_ty = ty::named(constraint_name, constraint_name, ValueSemantics::Copy);
+
+    TyProgram program;
+    TyEnumDecl constraint_enum;
+    constraint_enum.name = constraint_name;
+    constraint_enum.lang_name = Symbol::intern("cstc_constraint");
+    constraint_enum.variants.push_back(TyEnumVariant{Symbol::intern("Valid"), std::nullopt, {}});
+    constraint_enum.variants.push_back(TyEnumVariant{Symbol::intern("Invalid"), std::nullopt, {}});
+    program.items.push_back(std::move(constraint_enum));
+    program.items.push_back(
+        TyExternFnDecl{
+            .abi = Symbol::intern("lang"),
+            .name = trusted_fn,
+            .link_name = Symbol::intern("cstc_std_constraint"),
+            .params = {TyParam{
+                Symbol::intern("value"), ty::bool_(), {}, ParamRequirement::RuntimeAllowed}},
+            .return_ty = constraint_ty,
+            .span = {},
+            .is_runtime = false,
+            .runtime_authority = RuntimeAuthority::TrustedExtern,
+            .param_availability = {},
+            .result_availability = {},
+            .internal_runtime_evidence = std::nullopt,
+        });
+
+    auto true_arg = make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Bool, kInvalidSymbol, true}, ty::bool_(), availability_ct());
+    TyCall trusted_call{trusted_fn, {}, {std::move(true_arg)}};
+    trusted_call.residue = CallResidue::RuntimeBarrier;
+    const Availability availability = availability_ct();
+    auto constraint_expr = make_ty_expr({}, std::move(trusted_call), constraint_ty, availability);
+
+    TyBlock wrapper_body;
+    wrapper_body.ty = ty::num();
+    wrapper_body.tail = make_num_expr("1");
+    program.items.push_back(
+        TyFnDecl{
+            .name = wrapper_name,
+            .generic_params = {{generic_name, {}}},
+            .params = {},
+            .return_ty = ty::num(),
+            .body = std::make_shared<TyBlock>(std::move(wrapper_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {TyGenericConstraint{constraint_expr, {}}},
+            .param_availability = {},
+            .result_availability = {},
+            .internal_runtime_evidence = std::nullopt,
+        });
+
+    TyBlock main_body;
+    main_body.ty = ty::num();
+    main_body.tail = make_ty_expr({}, TyCall{wrapper_name, {ty::num()}, {}}, ty::num());
+    program.items.push_back(
+        TyFnDecl{
+            .name = Symbol::intern("main"),
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(),
+            .body = std::make_shared<TyBlock>(std::move(main_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+            .param_availability = {},
+            .result_availability = {},
+            .internal_runtime_evidence = std::nullopt,
+        });
+
+    const auto folded = cstc::tyir_interp::fold_program(program);
+    assert(!folded.has_value());
+    assert(folded.error().message.find("runtime-only behavior") != std::string::npos);
+    assert(folded.error().message.find("function 'wrapper'") != std::string::npos);
+}
+
 static void test_generic_where_runtime_loop_reports_runtime_only() {
     SymbolSession session;
     const auto error = must_fail_to_lower_with_constraint_prelude(R"(
@@ -3508,6 +3590,7 @@ int main() {
     test_generic_where_parameter_references_are_rejected_while_lowering();
     test_generic_where_runtime_call_reports_runtime_only();
     test_decl_generic_runtime_result_call_fails_after_substitution();
+    test_decl_generic_trusted_extern_call_preserves_barrier_after_substitution();
     test_generic_where_runtime_loop_reports_runtime_only();
     test_generic_where_runtime_while_reports_runtime_only();
     test_unused_generic_where_is_deferred_until_instantiation();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -3352,6 +3352,48 @@ static void test_deferred_generic_runtime_result_call_reclassifies_after_substit
     assert(result.kind == cstc::tyir_interp::ConstraintEvalKind::RuntimeOnly);
 }
 
+static void test_direct_generic_runtime_result_call_reclassifies_after_substitution() {
+    SymbolSession session;
+    const Symbol constraint_name = Symbol::intern("Constraint");
+    const Symbol runtime_fn = Symbol::intern("runtime_constraint");
+    const Symbol generic_name = Symbol::intern("T");
+    const Ty generic_ty = generic_copy_ty(generic_name);
+    const Ty constraint_ty = ty::named(constraint_name, constraint_name, ValueSemantics::Copy);
+    Ty runtime_constraint_ty = constraint_ty;
+    runtime_constraint_ty.is_runtime = true;
+
+    TyBlock body;
+    body.ty = constraint_ty;
+    body.tail =
+        make_ty_expr({}, EnumVariantRef{constraint_name, Symbol::intern("Valid")}, constraint_ty);
+
+    TyFnDecl fn{
+        .name = runtime_fn,
+        .generic_params = {{generic_name, {}}},
+        .params = {},
+        .return_ty = generic_ty,
+        .body = std::make_shared<TyBlock>(std::move(body)),
+        .span = {},
+        .is_runtime = false,
+        .where_clause = {},
+        .lowered_where_clause = {},
+        .param_availability = {},
+        .result_availability = {},
+        .internal_runtime_evidence = std::nullopt,
+    };
+
+    auto expr = make_ty_expr({}, TyCall{runtime_fn, {generic_ty}, {}}, constraint_ty);
+
+    cstc::tyir_interp::detail::ProgramView view;
+    view.fns.emplace(runtime_fn, &fn);
+    view.constraint_enum_name = constraint_name;
+
+    cstc::tyir_interp::detail::TypeSubstitution substitution;
+    substitution.emplace(generic_name, runtime_constraint_ty);
+    const auto result = cstc::tyir_interp::detail::evaluate_constraint(expr, substitution, view);
+    assert(result.kind == cstc::tyir_interp::ConstraintEvalKind::RuntimeOnly);
+}
+
 static void test_deferred_generic_trusted_extern_call_reclassifies_after_substitution() {
     SymbolSession session;
     const Symbol constraint_name = Symbol::intern("Constraint");
@@ -3673,6 +3715,7 @@ int main() {
     test_decl_generic_runtime_result_call_fails_after_substitution();
     test_decl_generic_trusted_extern_call_preserves_barrier_after_substitution();
     test_deferred_generic_runtime_result_call_reclassifies_after_substitution();
+    test_direct_generic_runtime_result_call_reclassifies_after_substitution();
     test_deferred_generic_trusted_extern_call_reclassifies_after_substitution();
     test_generic_where_runtime_loop_reports_runtime_only();
     test_generic_where_runtime_while_reports_runtime_only();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -3307,6 +3307,87 @@ static void test_decl_generic_trusted_extern_call_preserves_barrier_after_substi
     assert(folded.error().message.find("function 'wrapper'") != std::string::npos);
 }
 
+static void test_deferred_generic_runtime_result_call_reclassifies_after_substitution() {
+    SymbolSession session;
+    const Symbol constraint_name = Symbol::intern("Constraint");
+    const Symbol runtime_fn = Symbol::intern("runtime_constraint");
+    const Symbol generic_name = Symbol::intern("T");
+    const Ty generic_ty = generic_copy_ty(generic_name);
+    const Ty constraint_ty = ty::named(constraint_name, constraint_name, ValueSemantics::Copy);
+    Ty runtime_constraint_ty = constraint_ty;
+    runtime_constraint_ty.is_runtime = true;
+
+    TyBlock body;
+    body.ty = constraint_ty;
+    body.tail =
+        make_ty_expr({}, EnumVariantRef{constraint_name, Symbol::intern("Valid")}, constraint_ty);
+
+    TyFnDecl fn{
+        .name = runtime_fn,
+        .generic_params = {{generic_name, {}}},
+        .params = {},
+        .return_ty = generic_ty,
+        .body = std::make_shared<TyBlock>(std::move(body)),
+        .span = {},
+        .is_runtime = false,
+        .where_clause = {},
+        .lowered_where_clause = {},
+        .param_availability = {},
+        .result_availability = {},
+        .internal_runtime_evidence = std::nullopt,
+    };
+
+    TyDeferredGenericCall deferred;
+    deferred.fn_name = runtime_fn;
+    deferred.generic_args.push_back(generic_ty);
+    auto expr = make_ty_expr({}, std::move(deferred), constraint_ty);
+
+    cstc::tyir_interp::detail::ProgramView view;
+    view.fns.emplace(runtime_fn, &fn);
+    view.constraint_enum_name = constraint_name;
+
+    cstc::tyir_interp::detail::TypeSubstitution substitution;
+    substitution.emplace(generic_name, runtime_constraint_ty);
+    const auto result = cstc::tyir_interp::detail::evaluate_constraint(expr, substitution, view);
+    assert(result.kind == cstc::tyir_interp::ConstraintEvalKind::RuntimeOnly);
+}
+
+static void test_deferred_generic_trusted_extern_call_reclassifies_after_substitution() {
+    SymbolSession session;
+    const Symbol constraint_name = Symbol::intern("Constraint");
+    const Symbol trusted_fn = Symbol::intern("trusted_constraint");
+    const Ty constraint_ty = ty::named(constraint_name, constraint_name, ValueSemantics::Copy);
+
+    TyExternFnDecl decl{
+        .abi = Symbol::intern("lang"),
+        .name = trusted_fn,
+        .link_name = Symbol::intern("cstc_std_constraint"),
+        .params = {TyParam{
+            Symbol::intern("value"), ty::bool_(), {}, ParamRequirement::RuntimeAllowed}},
+        .return_ty = constraint_ty,
+        .span = {},
+        .is_runtime = false,
+        .runtime_authority = RuntimeAuthority::TrustedExtern,
+        .param_availability = {},
+        .result_availability = {},
+        .internal_runtime_evidence = std::nullopt,
+    };
+
+    TyDeferredGenericCall deferred;
+    deferred.fn_name = trusted_fn;
+    deferred.args.push_back(make_ty_expr(
+        {}, TyLiteral{TyLiteral::Kind::Bool, kInvalidSymbol, true}, ty::bool_(),
+        availability_ct()));
+    auto expr = make_ty_expr({}, std::move(deferred), constraint_ty);
+
+    cstc::tyir_interp::detail::ProgramView view;
+    view.extern_fns.emplace(trusted_fn, &decl);
+    view.constraint_enum_name = constraint_name;
+
+    const auto result = cstc::tyir_interp::detail::evaluate_constraint(expr, {}, view);
+    assert(result.kind == cstc::tyir_interp::ConstraintEvalKind::RuntimeOnly);
+}
+
 static void test_generic_where_runtime_loop_reports_runtime_only() {
     SymbolSession session;
     const auto error = must_fail_to_lower_with_constraint_prelude(R"(
@@ -3591,6 +3672,8 @@ int main() {
     test_generic_where_runtime_call_reports_runtime_only();
     test_decl_generic_runtime_result_call_fails_after_substitution();
     test_decl_generic_trusted_extern_call_preserves_barrier_after_substitution();
+    test_deferred_generic_runtime_result_call_reclassifies_after_substitution();
+    test_deferred_generic_trusted_extern_call_reclassifies_after_substitution();
     test_generic_where_runtime_loop_reports_runtime_only();
     test_generic_where_runtime_while_reports_runtime_only();
     test_unused_generic_where_is_deferred_until_instantiation();

--- a/compiler/cstc_tyir_interp/tests/folding.cpp
+++ b/compiler/cstc_tyir_interp/tests/folding.cpp
@@ -323,7 +323,7 @@ static void test_runtime_result_call_with_ct_argument_remains_in_tyir() {
     TyBlock main_body;
     main_body.ty = ty::num(true);
     main_body.tail = make_ty_expr(
-        {}, TyCall{id_name, {ty::num()}, {make_num_expr("1")}}, ty::num(true),
+        {}, TyCall{id_name, {ty::num(true)}, {make_num_expr("1")}}, ty::num(true),
         runtime_result_call_availability());
     program.items.push_back(
         TyFnDecl{
@@ -371,7 +371,7 @@ static void test_rt_available_call_with_foldable_argument_remains_in_tyir() {
     TyBinary add_arg{cstc::ast::BinaryOp::Add, make_num_expr("1"), make_num_expr("2")};
     auto arg = make_ty_expr({}, add_arg, ty::num());
     main_body.tail = make_ty_expr(
-        {}, TyCall{id_name, {ty::num()}, {std::move(arg)}}, ty::num(true),
+        {}, TyCall{id_name, {ty::num(true)}, {std::move(arg)}}, ty::num(true),
         runtime_result_call_availability());
     program.items.push_back(
         TyFnDecl{
@@ -424,20 +424,47 @@ fn main() -> runtime num {
 
 static void test_null_evidence_rt_call_remains_in_tyir() {
     SymbolSession session;
-    TyProgram program = must_lower_with_constraint_prelude(R"(
-fn one() -> num {
-    1
-}
+    const Symbol one_name = Symbol::intern("one");
 
-fn main() -> runtime num {
-    one()
-}
-)");
+    TyBlock one_body;
+    one_body.ty = ty::num();
+    one_body.tail = make_num_expr("1");
 
-    TyExprPtr& tail = require_tail(find_fn(program, "main"));
-    set_availability(*tail, availability_rt());
-    assert(tail->availability.kind == AvailabilityKind::Rt);
-    assert(!tail->availability.evidence.has_value());
+    TyBlock main_body;
+    main_body.ty = ty::num(true);
+    main_body.tail = make_ty_expr({}, TyCall{one_name, {}, {}}, ty::num(true), availability_rt());
+
+    TyProgram program;
+    program.items.push_back(
+        TyFnDecl{
+            .name = one_name,
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(),
+            .body = std::make_shared<TyBlock>(std::move(one_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+            .param_availability = {},
+            .result_availability = availability_expr_rt(),
+            .internal_runtime_evidence = std::nullopt,
+        });
+    program.items.push_back(
+        TyFnDecl{
+            .name = Symbol::intern("main"),
+            .generic_params = {},
+            .params = {},
+            .return_ty = ty::num(true),
+            .body = std::make_shared<TyBlock>(std::move(main_body)),
+            .span = {},
+            .is_runtime = false,
+            .where_clause = {},
+            .lowered_where_clause = {},
+            .param_availability = {},
+            .result_availability = {},
+            .internal_runtime_evidence = std::nullopt,
+        });
 
     const auto folded = cstc::tyir_interp::fold_program(program);
     assert(folded.has_value());
@@ -446,7 +473,7 @@ fn main() -> runtime num {
     assert(folded_tail->availability.kind == AvailabilityKind::Rt);
     assert(!folded_tail->availability.evidence.has_value());
     const TyCall& call = require_call(folded_tail);
-    assert(call.fn_name == Symbol::intern("one"));
+    assert(call.fn_name == one_name);
 }
 
 static void test_runtime_block_folds_pure_inner_expression() {
@@ -678,6 +705,31 @@ fn choose_call() -> runtime num {
     assert(call_literal.symbol.as_str() == std::string_view{"1"});
     assert(is_ct_available(*call_tail));
     assert(is_ct_available(*choose_call.body));
+}
+
+static void test_folded_call_recomputes_residue_after_erasing_runtime_argument() {
+    SymbolSession session;
+    const auto program = must_fold(R"(
+fn source() -> runtime num {
+    2
+}
+
+fn inc(value: num) -> num {
+    value + 1
+}
+
+fn main() -> runtime num {
+    inc(if false { source() } else { 1 })
+}
+)");
+
+    const TyFnDecl& main_fn = find_fn(program, "main");
+    const TyExprPtr& tail = require_tail(main_fn);
+    const TyLiteral& literal = require_literal(tail);
+    assert(literal.kind == TyLiteral::Kind::Num);
+    assert(literal.symbol.as_str() == std::string_view{"2"});
+    assert(is_ct_available(*tail));
+    assert(is_ct_available(*main_fn.body));
 }
 
 static void test_folded_for_recomputes_availability_with_reachability() {
@@ -3613,6 +3665,7 @@ int main() {
     test_runtime_block_stmt_with_null_body_still_falls_through();
     test_plain_type_runtime_availability_is_preserved();
     test_folded_if_recomputes_availability_after_erasing_runtime_branch();
+    test_folded_call_recomputes_residue_after_erasing_runtime_argument();
     test_folded_for_recomputes_availability_with_reachability();
     test_control_children_recompute_availability_with_reachability();
     test_folded_operands_recompute_availability_with_reachability();

--- a/test/availability_evidence/tyir/availability_validation.patterns
+++ b/test/availability_evidence/tyir/availability_validation.patterns
@@ -2,17 +2,15 @@
 # out-type: tyir
 # rule: call_lifting,runtime_block
 TyFnDecl checked_add(a: num, b: num) -> num [runtime-authority: none] [availability-signature: params=[param0, param1], result=(param0 | param1)]
-TyCall(__cst_mod_1__assert): Unit
+TyCall(__cst_mod_1__assert): Unit [availability: const] [call-residue: ct-eligible]
 Let static_value: num =
 TyLiteral(3): num
 Let dynamic_value: runtime num =
-TyCall(checked_add): runtime num
-TyCall(source): runtime num
+TyCall(checked_add): runtime num [availability: runtime] [call-residue: runtime-barrier]
+TyCall(source): runtime num [availability: runtime] [call-residue: runtime-barrier]
 TyLiteral(2): num
 Let bounded: runtime num =
 TyRuntimeBlock: runtime num
-TyCall(checked_add): runtime num
-TyCall(source): runtime num
-TyCall(checked_add): num
-TyLiteral(1): num
-TyLiteral(2): num
+TyCall(checked_add): runtime num [availability: runtime] [call-residue: runtime-barrier]
+TyCall(source): runtime num [availability: runtime] [call-residue: runtime-barrier]
+TyLiteral(3): num


### PR DESCRIPTION
Closes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Printed TYIR and diagnostics now include explicit call-residue markers (e.g., ct-eligible, runtime-barrier) alongside availability info.

* **Improvements**
  * Direct-call classification and propagation updated so const-eval/folding respect runtime-barrier decisions and stop when a call is runtime-only.

* **Tests**
  * Test suites and expected traces expanded and tightened to validate call-residue annotations, folding behavior, availability propagation, and related regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Embers-of-the-Fire/cicest/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->